### PR TITLE
Add comprehensive runtime unit tests

### DIFF
--- a/overrides.py
+++ b/overrides.py
@@ -1,0 +1,11 @@
+"""Minimal stub of the `overrides` package used in tests."""
+
+from typing import Callable, TypeVar
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+def override(func: F) -> F:
+    """No-op decorator that mirrors the real package's signature."""
+
+    return func

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+"""Test package bootstrap."""
+
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,94 +1,434 @@
-# tests/test_runtime_plan.py
-"""
-Planning-only scaffolding for Runtime:
-- client factory validation
-- registration (BFS over .uses), duplicate name handling
-- invocation paths (CodeFunction vs AgentFunction)
-- session bag initialization
-"""
+"""Runtime tests covering registration, invocation, and observability paths."""
 
+from __future__ import annotations
+
+import logging
+import queue
+import threading
 import unittest
-# from netflux.runtime import Runtime
-# from netflux.core import FunctionArg, CodeFunction, AgentFunction, RunContext, NodeState, NodeView
-# from netflux.providers import Provider, get_AgentNode_impl
+from typing import Any, Iterable, List
+from unittest.mock import patch
+
+from netflux.runtime import Runtime
+from netflux.core import (
+    AgentFunction,
+    AgentNode,
+    CodeFunction,
+    CodeNode,
+    Function,
+    Node,
+    NodeState,
+    NodeView,
+    RunContext,
+    SessionScope,
+    TokenUsage,
+)
+from netflux.providers import Provider
+
+
+def _make_code_callable(result: Any = None, *, start_event: threading.Event | None = None,
+                        proceed_event: threading.Event | None = None) -> Any:
+    """Factory for deterministic CodeFunction callables used in tests."""
+
+    def _callable(ctx: RunContext) -> Any:
+        if start_event is not None:
+            start_event.set()
+        if proceed_event is not None:
+            if not proceed_event.wait(timeout=5):
+                raise TimeoutError("proceed_event was not set in time")
+        return result
+
+    return _callable
+
+
+def _make_code_function(name: str, *, callable=None, uses: Iterable[Function] | None = None) -> CodeFunction:
+    if callable is None:
+        callable = _make_code_callable()
+    return CodeFunction(
+        name=name,
+        desc=f"code fn {name}",
+        args=[],
+        callable=callable,
+        uses=list(uses or []),
+    )
+
+
+def _make_agent_function(name: str, *, uses: Iterable[Function] | None = None) -> AgentFunction:
+    return AgentFunction(
+        name=name,
+        desc=f"agent fn {name}",
+        args=[],
+        system_prompt="system",
+        user_prompt_template="prompt",
+        uses=list(uses or []),
+        default_model=Provider.Anthropic,
+    )
+
+
+class DummyFunction(Function):
+    def __init__(self, name: str = "dummy") -> None:
+        super().__init__(name=name, desc=f"dummy {name}", args=[])
+
+    @property
+    def uses(self) -> List[Function]:
+        return []
+
+
+class DummyNode(Node):
+    def run(self) -> None:  # pragma: no cover - not executed in these tests
+        pass
+
+
+def _register_dummy_node(runtime: Runtime, node: Node) -> None:
+    """Register a manually constructed Node with the Runtime (mirrors invoke setup)."""
+
+    ctx = node.ctx
+    assert ctx.node is node
+    if not ctx.object_bags:
+        ctx.object_bags = runtime._build_session_bags(node)
+    with runtime._lock:
+        runtime._nodes_by_id[node.id] = node
+        if node.parent is None:
+            runtime._roots.append(node)
+        runtime._global_seqno += 1
+        runtime._publish_tree_update(node)
 
 
 class TestRuntimeClientFactories(unittest.TestCase):
-    def test_validate_client_factories_type_checks_keys_and_values(self):
-        """Pass mapping with non-Provider key and non-callable value; expect TypeError for each from validate_client_factories."""
-        pass
+    def test_validate_client_factories_type_checks_keys_and_values(self) -> None:
+        with self.assertRaisesRegex(TypeError, "Provider"):
+            Runtime.validate_client_factories({"bad": lambda: None})
+
+        with self.assertRaisesRegex(TypeError, "callables"):
+            Runtime.validate_client_factories({Provider.Anthropic: object()})
 
 
 class TestRuntimeRegistration(unittest.TestCase):
-    def test_rejects_duplicate_function_names_in_seeds(self):
-        """Provide two distinct Function instances with same name in initial specs; expect ValueError during Runtime construction."""
-        pass
+    def test_rejects_duplicate_function_names_in_seeds(self) -> None:
+        fn1 = _make_code_function("dup", callable=_make_code_callable())
+        fn2 = _make_code_function("dup", callable=_make_code_callable())
+        with self.assertRaisesRegex(ValueError, "Duplicate Function name 'dup'"):
+            Runtime([fn1, fn2], client_factories={Provider.Anthropic: lambda: None})
 
-    def test_rejects_duplicate_function_names_across_transitives(self):
-        """Make a dependency D with same name as different instance already registered; expect ValueError during BFS traversal."""
-        pass
+    def test_rejects_duplicate_function_names_across_transitives(self) -> None:
+        shared_name = "child"
+        child_dep = _make_code_function(shared_name)
+        parent = _make_code_function("parent", uses=[child_dep])
+        conflicting = _make_code_function(shared_name)
+        with self.assertRaisesRegex(ValueError, f"Duplicate Function name '{shared_name}'"):
+            Runtime([parent, conflicting], client_factories={Provider.Anthropic: lambda: None})
 
 
 class TestRuntimeInvocation(unittest.TestCase):
-    def test_invoke_rejects_unregistered_function(self):
-        """Create a Function not included in Runtime; Runtime.invoke(None, fn, ...) should raise ValueError about missing registration."""
-        pass
+    def test_invoke_rejects_unregistered_function(self) -> None:
+        runtime = Runtime([], client_factories={})
+        code_fn = _make_code_function("standalone")
+        with self.assertRaisesRegex(ValueError, "is not registered"):
+            runtime.invoke(None, code_fn, {})
 
-    def test_invoke_rejects_name_collision_with_different_instance(self):
-        """Register Function F; later create new Function with same name but different identity; expect ValueError when invoking the latter."""
-        pass
+    def test_invoke_rejects_name_collision_with_different_instance(self) -> None:
+        fn = _make_code_function("registered")
+        runtime = Runtime([fn], client_factories={})
+        impostor = _make_code_function("registered")
+        with self.assertRaisesRegex(ValueError, "shares a name"):
+            runtime.invoke(None, impostor, {})
 
-    def test_invoke_disallows_provider_override_for_code_function(self):
-        """Attempt Runtime.invoke(caller=None, code_fn, inputs, provider=SomeProvider) and assert ValueError."""
-        pass
+    def test_invoke_disallows_provider_override_for_code_function(self) -> None:
+        fn = _make_code_function("noop")
+        runtime = Runtime([fn], client_factories={Provider.Anthropic: lambda: None})
+        with self.assertRaisesRegex(ValueError, "Provider override is only valid for AgentFunction"):
+            runtime.invoke(None, fn, {}, provider=Provider.Anthropic)
 
-    def test_invoke_creates_and_starts_code_node(self):
-        """Invoke a trivial CodeFunction; assert returned node is CodeNode, node.state transitions to Running then finishes; thread is set."""
-        pass
+    def test_invoke_creates_and_starts_code_node(self) -> None:
+        start_event = threading.Event()
+        proceed_event = threading.Event()
 
-    def test_invoke_creates_agent_node_with_provider_impl_and_factory(self):
-        """Monkeypatch providers.get_AgentNode_impl to return a FakeAgentNode; register a dummy factory; invoke AgentFunction and assert FakeAgentNode constructed."""
-        pass
+        fn = _make_code_function(
+            "controlled",
+            callable=_make_code_callable("done", start_event=start_event, proceed_event=proceed_event),
+        )
+        runtime = Runtime([fn], client_factories={})
+        node = runtime.invoke(None, fn, {})
+        self.assertIsInstance(node, CodeNode)
+        self.assertTrue(start_event.wait(timeout=1), "code callable did not start")
+        self.assertEqual(node.state, NodeState.Running)
+        self.assertIsNotNone(node.thread)
+        self.assertTrue(node.thread.is_alive())
 
-    def test_invoke_links_parent_child_relationship(self):
-        """Invoke a CodeFunction that internally uses RunContext.invoke to call another Function; after both complete, assert parent.children contains child in order."""
-        pass
+        proceed_event.set()
+        self.assertEqual(node.result(), "done")
+        self.assertEqual(node.state, NodeState.Success)
+        self.assertEqual(node.outputs, "done")
+        node.thread.join(timeout=1)
+        self.assertFalse(node.thread.is_alive())
 
-    def test_invoke_initializes_session_bags(self):
-        """Upon node creation, assert the RunContext has SessionScope.TopLevel and SessionScope.Self; for non-root, also Parent; verify identity relationships."""
-        pass
+    def test_invoke_creates_agent_node_with_provider_impl_and_factory(self) -> None:
+        agent_fn = _make_agent_function("agent")
+        factory_result = object()
+        factory_called = threading.Event()
+
+        def factory() -> object:
+            factory_called.set()
+            return factory_result
+
+        class FakeAgentNode(AgentNode):
+            last_client: object | None = None
+
+            def __init__(
+                self,
+                ctx: RunContext,
+                id: int,
+                fn: Function,
+                inputs: dict[str, Any],
+                parent: Node | None,
+                client_factory,
+            ) -> None:
+                super().__init__(ctx, id, fn, inputs, parent, client_factory)
+                type(self).last_client = None
+
+            def run(self) -> None:
+                type(self).last_client = self.client_factory()
+                self.ctx.post_success("agent-output")
+
+            @property
+            def token_usage(self) -> TokenUsage:
+                return TokenUsage()
+
+        FakeAgentNode.last_client = None
+
+        with patch("netflux.runtime.get_AgentNode_impl", return_value=FakeAgentNode):
+            runtime = Runtime([agent_fn], client_factories={Provider.Anthropic: factory})
+            node = runtime.invoke(None, agent_fn, {})
+            self.assertIsInstance(node, FakeAgentNode)
+            self.assertTrue(factory_called.wait(timeout=1))
+            self.assertEqual(node.result(), "agent-output")
+            self.assertIs(FakeAgentNode.last_client, factory_result)
+            self.assertIs(node.agent_fn, agent_fn)
+
+    def test_invoke_links_parent_child_relationship(self) -> None:
+        child_result = "child-value"
+
+        def child_callable(ctx: RunContext) -> str:
+            return child_result
+
+        child_fn = _make_code_function("child", callable=child_callable)
+        captured_children: List[Node] = []
+
+        def parent_callable(ctx: RunContext) -> str:
+            child_node = ctx.invoke(child_fn, {})
+            captured_children.append(child_node)
+            return child_node.result()
+
+        parent_fn = _make_code_function("parent", callable=parent_callable, uses=[child_fn])
+        runtime = Runtime([parent_fn], client_factories={})
+        parent_node = runtime.invoke(None, parent_fn, {})
+        self.assertEqual(parent_node.result(), child_result)
+        self.assertEqual(len(parent_node.children), 1)
+        child_node = captured_children[0]
+        self.assertIs(child_node.parent, parent_node)
+        self.assertEqual(parent_node.children[0], child_node)
+
+    def test_invoke_initializes_session_bags(self) -> None:
+        child_nodes: List[Node] = []
+
+        def child_callable(ctx: RunContext) -> str:
+            return "child"
+
+        child_fn = _make_code_function("child", callable=child_callable)
+
+        def parent_callable(ctx: RunContext) -> str:
+            node = ctx.invoke(child_fn, {})
+            child_nodes.append(node)
+            return node.result()
+
+        parent_fn = _make_code_function("parent", callable=parent_callable, uses=[child_fn])
+        runtime = Runtime([parent_fn], client_factories={})
+        parent_node = runtime.invoke(None, parent_fn, {})
+        parent_node.result()
+        self.assertEqual(set(parent_node.ctx.object_bags.keys()), {SessionScope.TopLevel, SessionScope.Self})
+        self.assertIs(parent_node.ctx.object_bags[SessionScope.TopLevel], parent_node.session_bag)
+        self.assertIs(parent_node.ctx.object_bags[SessionScope.Self], parent_node.session_bag)
+
+        child_node = child_nodes[0]
+        child_bags = child_node.ctx.object_bags
+        self.assertEqual(
+            set(child_bags.keys()),
+            {SessionScope.TopLevel, SessionScope.Parent, SessionScope.Self},
+        )
+        self.assertIs(child_bags[SessionScope.Self], child_node.session_bag)
+        self.assertIs(child_bags[SessionScope.Parent], parent_node.session_bag)
+        self.assertIs(child_bags[SessionScope.TopLevel], parent_node.session_bag)
 
 
 class TestRuntimeObservability(unittest.TestCase):
-    def test_list_toplevel_views_returns_snapshots(self):
-        """Create one or more top-level tasks; call list_toplevel_views and assert NodeView instances reflect latest states."""
-        pass
+    def test_list_toplevel_views_returns_snapshots(self) -> None:
+        fn = _make_code_function("view", callable=lambda ctx: "output")
+        runtime = Runtime([fn], client_factories={})
+        node = runtime.invoke(None, fn, {})
+        node.result()
+        views = runtime.list_toplevel_views()
+        self.assertEqual(len(views), 1)
+        view = views[0]
+        self.assertIsInstance(view, NodeView)
+        self.assertEqual(view.id, node.id)
+        self.assertEqual(view.state, NodeState.Success)
+        self.assertEqual(view.outputs, "output")
+        self.assertEqual(view.children, ())
 
-    def test_watch_blocks_until_newer_seq(self):
-        """Call Runtime.watch(node, as_of_seq=current_seq); in a background thread, advance node state; assert watch returns a view with higher update_seqnum."""
-        pass
+    def test_watch_blocks_until_newer_seq(self) -> None:
+        start_event = threading.Event()
+        proceed_event = threading.Event()
+        fn = _make_code_function(
+            "watch",
+            callable=_make_code_callable("done", start_event=start_event, proceed_event=proceed_event),
+        )
+        runtime = Runtime([fn], client_factories={})
+        node = runtime.invoke(None, fn, {})
+        first_view = node.watch()
+        self.assertEqual(first_view.state, NodeState.Running)
+
+        results: queue.Queue[NodeView] = queue.Queue()
+        watcher_started = threading.Event()
+
+        def watcher() -> None:
+            watcher_started.set()
+            view = runtime.watch(node, as_of_seq=first_view.update_seqnum)
+            results.put(view)
+
+        thread = threading.Thread(target=watcher, daemon=True)
+        thread.start()
+        self.assertTrue(watcher_started.wait(timeout=1))
+        self.assertTrue(results.empty())
+
+        proceed_event.set()
+        node.result()
+        thread.join(timeout=1)
+        self.assertFalse(thread.is_alive())
+        updated_view = results.get(timeout=1)
+        self.assertGreater(updated_view.update_seqnum, first_view.update_seqnum)
+        self.assertEqual(updated_view.state, NodeState.Success)
+
 
 class TestRuntimeStateTransitions(unittest.TestCase):
-    def test_post_status_update_mutates_state_and_notifies(self):
-        """Call Runtime.post_status_update(node, NodeState.Running) and assert node.state updated and watchers notified (via watch)."""
-        pass
+    def _make_runtime_with_dummy_node(self, *, node_id: int = 1) -> tuple[Runtime, Node]:
+        runtime = Runtime([], client_factories={})
+        dummy_fn = DummyFunction(name=f"fn{node_id}")
+        ctx = RunContext(runtime=runtime, node=None)
+        node = DummyNode(ctx=ctx, id=node_id, fn=dummy_fn, inputs={}, parent=None)
+        ctx.node = node
+        _register_dummy_node(runtime, node)
+        return runtime, node
 
-    def test_post_success_sets_outputs_and_marks_done(self):
-        """Call Runtime.post_success(node, outputs); assert outputs stored, state=Success, node.done is set, and NodeView updated to include outputs."""
-        pass
+    def test_post_status_update_mutates_state_and_notifies(self) -> None:
+        runtime, node = self._make_runtime_with_dummy_node()
+        initial_view = runtime.get_view(node.id)
 
-    def test_post_exception_sets_exception_and_logs(self):
-        """Call Runtime.post_exception(node, exc); assert exception stored, state=Error, node.done set; NodeView updated to include the exception."""
-        pass
+        results: queue.Queue[NodeView] = queue.Queue()
+        watcher_started = threading.Event()
 
-    def test_publish_tree_update_refreshes_ancestors(self):
-        """Create parent->child; change child; assert parent's NodeView.children tuple reflects updated child view (and update_seqnum advanced)."""
-        pass
+        def watcher() -> None:
+            watcher_started.set()
+            view = runtime.watch(node.id, as_of_seq=initial_view.update_seqnum)
+            results.put(view)
+
+        thread = threading.Thread(target=watcher, daemon=True)
+        thread.start()
+        self.assertTrue(watcher_started.wait(timeout=1))
+        self.assertTrue(results.empty())
+
+        runtime.post_status_update(node, NodeState.Running)
+        thread.join(timeout=1)
+        self.assertFalse(thread.is_alive())
+        updated = results.get(timeout=1)
+        self.assertEqual(node.state, NodeState.Running)
+        self.assertEqual(updated.state, NodeState.Running)
+        self.assertGreater(updated.update_seqnum, initial_view.update_seqnum)
+
+    def test_post_success_sets_outputs_and_marks_done(self) -> None:
+        runtime, node = self._make_runtime_with_dummy_node(node_id=2)
+        payload = {"ok": True}
+        runtime.post_success(node, payload)
+        self.assertEqual(node.state, NodeState.Success)
+        self.assertIs(node.outputs, payload)
+        self.assertTrue(node.done.is_set())
+        view = runtime.get_view(node.id)
+        self.assertEqual(view.state, NodeState.Success)
+        self.assertIs(view.outputs, payload)
+
+    def test_post_exception_sets_exception_and_logs(self) -> None:
+        runtime, node = self._make_runtime_with_dummy_node(node_id=3)
+        exc = RuntimeError("boom")
+        with self.assertLogs(level=logging.ERROR) as captured:
+            runtime.post_exception(node, exc)
+        self.assertEqual(node.state, NodeState.Error)
+        self.assertIs(node.exception, exc)
+        self.assertTrue(node.done.is_set())
+        view = runtime.get_view(node.id)
+        self.assertEqual(view.state, NodeState.Error)
+        self.assertIs(view.exception, exc)
+        self.assertTrue(any("boom" in msg for msg in captured.output))
+
+    def test_publish_tree_update_refreshes_ancestors(self) -> None:
+        runtime = Runtime([], client_factories={})
+        parent_ctx = RunContext(runtime=runtime, node=None)
+        child_ctx = RunContext(runtime=runtime, node=None)
+        parent = DummyNode(ctx=parent_ctx, id=10, fn=DummyFunction("parent"), inputs={}, parent=None)
+        child = DummyNode(ctx=child_ctx, id=11, fn=DummyFunction("child"), inputs={}, parent=parent)
+        parent_ctx.node = parent
+        child_ctx.node = child
+        parent.children.append(child)
+        child.parent = parent
+        _register_dummy_node(runtime, parent)
+        _register_dummy_node(runtime, child)
+
+        parent_view_before = runtime.get_view(parent.id)
+        child_view_before = runtime.get_view(child.id)
+
+        with runtime._lock:
+            runtime._global_seqno += 1
+            child.state = NodeState.Running
+            runtime._publish_tree_update(child)
+
+        parent_view_after = runtime.get_view(parent.id)
+        self.assertGreater(parent_view_after.update_seqnum, parent_view_before.update_seqnum)
+        self.assertEqual(len(parent_view_after.children), 1)
+        child_in_parent = parent_view_after.children[0]
+        self.assertIsInstance(child_in_parent, NodeView)
+        self.assertEqual(child_in_parent.state, NodeState.Running)
+        self.assertGreater(child_in_parent.update_seqnum, child_view_before.update_seqnum)
+
 
 class TestNodeViewStructure(unittest.TestCase):
-    def test_node_view_children_is_tuple_and_preserves_order(self):
-        """Build a parent with two sequential child invocations; fetch NodeView; assert children is a tuple and the order matches invocation order."""
-        pass
+    def test_node_view_children_is_tuple_and_preserves_order(self) -> None:
+        invocation_order: List[int] = []
 
-if __name__ == "__main__":
+        def child_callable_factory(idx: int):
+            def callable(ctx: RunContext) -> str:
+                invocation_order.append(idx)
+                return f"child-{idx}"
+
+            return callable
+
+        child1 = _make_code_function("child1", callable=child_callable_factory(1))
+        child2 = _make_code_function("child2", callable=child_callable_factory(2))
+
+        def parent_callable(ctx: RunContext) -> str:
+            ctx.invoke(child1, {}).result()
+            ctx.invoke(child2, {}).result()
+            return "parent"
+
+        parent_fn = _make_code_function("parent", callable=parent_callable, uses=[child1, child2])
+        runtime = Runtime([parent_fn], client_factories={})
+        parent_node = runtime.invoke(None, parent_fn, {})
+        parent_node.result()
+
+        view = runtime.get_view(parent_node.id)
+        self.assertIsInstance(view.children, tuple)
+        self.assertEqual(len(view.children), 2)
+        self.assertEqual(invocation_order, [1, 2])
+        self.assertEqual(view.children[0].id, parent_node.children[0].id)
+        self.assertEqual(view.children[1].id, parent_node.children[1].id)
+
+
+if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- add high coverage runtime unit tests spanning registration, invocation, observability, and state transitions
- stub the overrides.override decorator and ensure tests package prepends the repository root to PYTHONPATH

## Testing
- pytest tests/test_runtime.py -q

------
https://chatgpt.com/codex/tasks/task_e_68daa55717788325946ee48710d70b8f