### PR TITLE
Add cancellation token support to runtime and agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ while True:
     # read view.state / view.outputs / view.exception / view.children safely
     print(f"[{view.update_seqnum}] node={view.id} state={view.state.name}")
     
-    if view.state in (NodeState.Success, NodeState.Error):
+    if view.state in (NodeState.Success, NodeState.Error, NodeState.Canceled):
         break
 ```
 
@@ -394,7 +394,7 @@ while True:
     for child in view.children:
         print(f"  └─ child id={child.id} fn={child.fn.name} state={child.state.name}")
 
-    if view.state in (NodeState.Success, NodeState.Error):
+    if view.state in (NodeState.Success, NodeState.Error, NodeState.Canceled):
         break
 
 # Finally, print the result or surface the exception.
@@ -512,11 +512,16 @@ This refined example shows:
     * `node: Optional[Node]`: a reference to the particular `Node` identifying this specific `Function` invocation. `None` for top-level contexts.
     * `runtime: Runtime`: a reference to the shared `Runtime`.
     * `object_bags: Dict[SessionScope, SessionBag]`: references to session bags accessible at different scopes.
+    * `cancel_event: Optional[multiprocessing.Event]`: cooperative cancellation token inherited from the caller unless explicitly overridden.
 * Methods:
-    * `invoke(fn: Function, args: Dict[str, Any], provider: Optional[Provider] = None) -> Node`: invoke a `Function` and return the created `Node`.
+    * `invoke(fn: Function, args: Dict[str, Any], provider: Optional[Provider] = None, cancel_event: Optional[multiprocessing.Event] = None) -> Node`: invoke a `Function`, optionally overriding the cancellation scope, and return the created `Node`.
     * `post_status_update(state: NodeState)`: update the current node's status.
     * `post_success(outputs: Any)`: mark the current node as successful with given outputs.
     * `post_exception(exception: Exception)`: mark the current node as failed with given exception.
+    * `post_cancel()`: mark the current node as canceled cooperatively.
+    * `cancel_requested() -> bool`: helper to check whether the associated cancellation token has been triggered.
+
+`CancelEvent` is a thin alias for `multiprocessing.Event`. Consumers can pass an event at the top level (or override it for specific children) to establish cooperative cancellation scopes. When set, participating nodes surface a `CancellationException`, and the runtime records the node in the `NodeState.Canceled` terminal state.
 * Narrow Scope: `RunContext` is just a mechanism to pass on `Function` invocation directives to the `Runtime` to act on them.
 
 ## `Node`
@@ -535,7 +540,7 @@ This refined example shows:
     * Child `Function` invocations are tracked in `node.children: List[Node]` property.
         * Always ordered to reflect the sequence in which `Function`s were invoked. 
         * For consumers outside the framework, use `NodeView.children: tuple[NodeView, ...]` instead to access child information safely.
-    * Has states (Waiting, Running, Success, Error) but also sub-state including tool use (`Function` invocation) that it is waiting on.
+    * Has states (Waiting, Running, Success, Error, Canceled) but also sub-state including tool use (`Function` invocation) that it is waiting on.
     * `AgentNode` is completed once it returns final assistant text or the model decides to `RaiseException` (if it has been given as an option).
     * `TokenUsage` cumulative accounting must be reportable by every `AgentNode` and kept up to date throughout the agent loop (updated on every request/response iteration).
         * Subtype implementations must use the provider SDK's token usage meta to track the accumulation.
@@ -548,7 +553,7 @@ This refined example shows:
     * `inputs: Dict[str, Any]`: What the inputs were for the invocation.
     * `outputs: Optional[Any]`: What the output(s) were from the run (if finished). Usually just an unstructured string.
     * `exception: Optional[Exception]`: the exception, if there was an exception.
-    * `state: NodeState`: (Waiting, Running, Success, Error) enum
+    * `state: NodeState`: (Waiting, Running, Success, Error, Canceled) enum
     * `children: List[Node]`: ordered list of child `Function` invocations made by this `Node`.
     * **Note**: External consumers should access this information through `NodeView` instead of `Node` directly to avoid race conditions.
 

--- a/core.py
+++ b/core.py
@@ -6,6 +6,7 @@ import traceback
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Type, Union, get_args
 import inspect
 from threading import Thread, Event, Lock
+from multiprocessing import Event as MultiprocessingEvent
 from overrides import override
 
 AllowedArgTypeUnion = Union[Type[str], Type[int], Type[float], Type[bool]]
@@ -15,11 +16,25 @@ AllowedArgTypeTuple: tuple[type, ...] = tuple(
 
 from .providers import Provider
 
+CancelEvent = MultiprocessingEvent
+
+
+class CancellationException(Exception):
+    """Raised when a node cooperatively acknowledges a cancellation request."""
+
+    def __init__(self, message: str = "Operation canceled") -> None:
+        super().__init__(message)
+
+
 class NodeState(Enum):
     Waiting = "Waiting"
     Running = "Running"
     Success = "Success"
     Error = "Error"
+    Canceled = "Canceled"
+
+
+TerminalNodeStates = (NodeState.Success, NodeState.Error, NodeState.Canceled)
 
 class SessionScope(Enum):
     # Refers to the lifetime of the entire top-level invocation tree.
@@ -324,14 +339,30 @@ class RunContext:
     runtime: 'Runtime'      # type: ignore
     node: Optional['Node']  # None outside of any top-level task.
     object_bags: Dict[SessionScope, SessionBag] = field(default_factory=dict)
+    cancel_event: Optional[CancelEvent] = None
 
-    def invoke(self, fn: Function, args: Dict[str, Any], provider: Optional[Provider] = None) -> 'Node':
+    def invoke(
+        self,
+        fn: Function,
+        args: Dict[str, Any],
+        provider: Optional[Provider] = None,
+        cancel_event: Optional[CancelEvent] = None,
+    ) -> 'Node':
         """
         Proxy to the Runtime to invoke a Function and create associated Node + edges.
-        Returns the created `Node`. For AgentFunction calls only, optionally specify `provider` to override the default
-        model.
+        Returns the created `Node`.
+
+        For AgentFunction calls only, optionally specify `provider` to override the default model.
+        Provide `cancel_event` to enforce a particular cancellation scope for the child node. When omitted,
+        the Runtime inherits the caller's CancelEvent (if any).
         """
-        return self.runtime.invoke(self.node, fn, args, provider=provider)
+        return self.runtime.invoke(
+            self.node,
+            fn,
+            args,
+            provider=provider,
+            cancel_event=cancel_event,
+        )
 
     def post_status_update(self, state: 'NodeState') -> None:
         if self.node is None:
@@ -347,6 +378,14 @@ class RunContext:
         if self.node is None:
             raise RuntimeError("post_exception may only be called from within a Node execution context")
         self.runtime.post_exception(self.node, exception)
+
+    def post_cancel(self, exception: Optional[CancellationException] = None) -> None:
+        if self.node is None:
+            raise RuntimeError("post_cancel may only be called from within a Node execution context")
+        self.runtime.post_cancel(self.node, exception)
+
+    def cancel_requested(self) -> bool:
+        return bool(self.cancel_event and self.cancel_event.is_set())
 
     def _resolve_bag(self, scope: SessionScope) -> SessionBag:
         if self.node is None:
@@ -384,7 +423,15 @@ class NodeView:
     update_seqnum: int  # Seqnum when this NodeView was generated.
 
 class Node(ABC):
-    def __init__(self, ctx: RunContext, id: int, fn: Function, inputs: Dict[str, Any], parent: Optional['Node']) -> None:
+    def __init__(
+        self,
+        ctx: RunContext,
+        id: int,
+        fn: Function,
+        inputs: Dict[str, Any],
+        parent: Optional['Node'],
+        cancel_event: Optional[CancelEvent],
+    ) -> None:
         self.ctx: RunContext = ctx
         self.id: int = id
         self.fn: Function = fn
@@ -396,6 +443,7 @@ class Node(ABC):
         self.thread: Optional[Thread] = None
         self.done: Event = Event()
         self.session_bag: SessionBag = SessionBag()
+        self.cancel_event: Optional[CancelEvent] = cancel_event
 
         assert isinstance(ctx, RunContext)
         assert isinstance(fn, Function)
@@ -415,9 +463,11 @@ class Node(ABC):
     def run_wrapper(self) -> None:
         try:
             self.run()
+        except CancellationException as ex:
+            self.ctx.post_cancel(ex)
         except Exception as ex:
             self.ctx.post_exception(ex)
-        assert self.state in (NodeState.Success, NodeState.Error)
+        assert self.state in TerminalNodeStates
         assert self.done.is_set()
 
     @abstractmethod
@@ -436,11 +486,18 @@ class Node(ABC):
         if self.state == NodeState.Error:
             assert self.exception
             raise self.exception
+        if self.state == NodeState.Canceled:
+            raise self.exception or CancellationException()
         return self.outputs
 
     def watch(self, as_of_seq: int = 0) -> NodeView:
         """Return the latest NodeView update (blocking until seq > view.update_seqnum)."""
         return self.ctx.runtime.watch(self, as_of_seq=as_of_seq)
+
+    def cancel_requested(self) -> bool:
+        if self.cancel_event is None:
+            return False
+        return self.cancel_event.is_set()
 
 class CodeNode(Node):
     """
@@ -457,8 +514,16 @@ class CodeNode(Node):
     output string. Alternatively, the Callable may raise an Exception, which will be
     propagated upon calling `node.result()`.
     """
-    def __init__(self, ctx: RunContext, id: int, fn: Function, inputs: Dict[str, Any], parent: Optional[Node]):
-        super().__init__(ctx, id, fn, inputs, parent)
+    def __init__(
+        self,
+        ctx: RunContext,
+        id: int,
+        fn: Function,
+        inputs: Dict[str, Any],
+        parent: Optional[Node],
+        cancel_event: Optional[CancelEvent],
+    ):
+        super().__init__(ctx, id, fn, inputs, parent, cancel_event)
         assert isinstance(self.fn, CodeFunction)
 
     def run(self) -> None:
@@ -467,6 +532,8 @@ class CodeNode(Node):
         try:
             result = func.callable(self.ctx, **self.inputs)
             self.ctx.post_success(result)
+        except CancellationException as e:
+            self.ctx.post_cancel(e)
         except Exception as e:
             self.ctx.post_exception(e)
 
@@ -488,9 +555,10 @@ class AgentNode(Node):
         fn: Function,
         inputs: Dict[str, Any],
         parent: Optional[Node],
+        cancel_event: Optional[CancelEvent],
         client_factory: Callable[[], Any],
     ) -> None:
-        super().__init__(ctx, id, fn, inputs, parent)
+        super().__init__(ctx, id, fn, inputs, parent, cancel_event)
         assert isinstance(fn, AgentFunction), "AgentNode must wrap an AgentFunction"
         self.agent_fn: AgentFunction = fn
         self.transcript: List[TranscriptPart] = []
@@ -518,6 +586,9 @@ class AgentNode(Node):
         except AgentException as e:
             # Safety: agents shouldn't bubble this far, but if they do, honor it.
             self.ctx.post_exception(e)
+        except CancellationException as e:
+            # Safety: agents shouldn't bubble this far, as they would have post_cancel() in their `run()`, but if they do, honor it.
+            self.ctx.post_cancel(e)
         except Exception as ex:
             mpe = ModelProviderException(
                 message=f"The provider of the agent's model (the driver) faulted due to: "
@@ -528,7 +599,7 @@ class AgentNode(Node):
                 inner_exception=ex,
             )
             self.ctx.post_exception(mpe)
-        assert self.state in (NodeState.Success, NodeState.Error)
+        assert self.state in TerminalNodeStates
         assert self.done.is_set()
 
     def build_user_text(self) -> str:

--- a/tests/test_agentnode.py
+++ b/tests/test_agentnode.py
@@ -15,6 +15,18 @@ from ..runtime import Runtime
 class _FakeAgentNode(AgentNode):
     """Minimal AgentNode for tests. Default run() is a no-op; tests can subclass/override."""
 
+    def __init__(
+        self,
+        ctx: RunContext,
+        id: int,
+        fn: AgentFunction,
+        inputs: dict,
+        parent=None,
+        cancel_event=None,
+        client_factory=None,
+    ) -> None:
+        super().__init__(ctx, id, fn, inputs, parent, cancel_event, client_factory)
+
     @property
     def token_usage(self) -> TokenUsage:
         return TokenUsage()


### PR DESCRIPTION
## Summary
- add a CancelEvent alias, CancellationException, and NodeState.Canceled so cancellation scopes flow through RunContext, Node, and Runtime
- teach provider agent loops, the ensemble decorator, and tree view docs to check cancellation tokens and surface canceled state
- document the new behaviour and extend unit tests to cover cancellation propagation and Runtime.post_cancel()

## Testing
- pytest --ignore=demos/test_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68dbc67666ac8325bb83138344d1a447