### PR TITLE
Improve support for users behind proxies with anthropic models

### DIFF
--- a/providers/anthropic.py
+++ b/providers/anthropic.py
@@ -113,8 +113,8 @@ from anthropic.types.tool_param import InputSchemaTyped
 INTERLEAVED_BETA = {"anthropic-beta": "interleaved-thinking-2025-05-14"}
 # "With interleaved thinking, the budget_tokens can exceed the max_tokens parameter,
 # as it represents the total budget across all thinking blocks within one assistant turn."
-MAX_TOKENS = 32_000
-THINKING_CFG = ThinkingConfigEnabledParam(type="enabled", budget_tokens=80_000)
+MAX_TOKENS = 64_000
+THINKING_CFG = ThinkingConfigEnabledParam(type="enabled", budget_tokens=62_000)
 # 5-minute TTL prompt cache watermark on the latest user request msg (initial + after tool_result).
 CACHE_TTL = "5m"
 # Prevent agent loop runaway. Max tool call + response cycles before giving up.
@@ -532,7 +532,12 @@ class AnthropicAgentNode(AgentNode):
         if idx is None:
             return out
 
-        cc = CacheControlEphemeralParam(type="ephemeral", ttl=ttl)
+        cc: CacheControlEphemeralParam
+        if ttl == '5m':
+            # Omit the `ttl` argument (default) because older clients may not support it.
+            cc = CacheControlEphemeralParam(type="ephemeral")
+        else:
+            cc = CacheControlEphemeralParam(type="ephemeral", ttl=ttl)
         orig_blocks = cast(List[Any], out[idx]["content"])
         assert orig_blocks, "User message content is empty"
         new_blocks: List[Any] = []

--- a/viz/console.py
+++ b/viz/console.py
@@ -102,9 +102,9 @@ def _format_elapsed(nv: NodeView) -> Optional[str]:
     - Terminal: green [Xs]
     - Waiting/no start: None
 
-    Keeps string short (1 decimal; <1s -> 2 decimals) to minimize interaction
-    with UI cropping. The ANSI wrapper is self-contained so cropping logic that
-    trims trailing partial CSI remains safe.
+    Keeps string short (1 decimal). For durations <1s, hide it entirely to
+    avoid visual noise. The ANSI wrapper is self-contained so cropping logic
+    that trims trailing partial CSI remains safe.
     """
     start = nv.started_at
     if start is None:
@@ -114,10 +114,10 @@ def _format_elapsed(nv: NodeView) -> Optional[str]:
         end = nv.ended_at
     tnow = time.time()
     elapsed = max(0.0, (end if end is not None else tnow) - start)
+    # Hide sub-second durations entirely
     if elapsed < 1.0:
-        s = f"{elapsed:.2f}s"
-    else:
-        s = f"{elapsed:.1f}s"
+        return None
+    s = f"{elapsed:.1f}s"
     # color by state (running=red, done=green)
     if nv.state is NodeState.Running:
         body = _color(s, fg="red")


### PR DESCRIPTION
- For proxies that don't propagate beta headers, we increase max_tokens to 64k for anthropic and 62k thinking budget.
- For proxies that don't speak recent arguments, and disallow extra body arguments, we remove the `ttl` arg for `CacheControlEphemeralParam` if the TTL is set to `5m` only (the default) which is currently the constant that was hard-coded in `providers/anthropic.py`.
- For proxies that don't propagate the interleaved reasoning beta header, we add a `thinking_scratchpad` CodeFunction that can serve as a thinking/reasoning block if the model chooses to use it (simply by using the arg as the scratchpad space itself).