### PR TITLE
Retry Incomplete Anthropic Streams With Missing stop_reason (rare corner case SDK protocol violation)

### DIFF
--- a/providers/anthropic.py
+++ b/providers/anthropic.py
@@ -199,6 +199,15 @@ class AnthropicAgentNode(AgentNode):
                         output_config=OUTPUT_CFG,
                     ) as stream:
                         resp = stream.get_final_message()
+
+                        # Observed rare corner case: SDK may return a partial streamed Message snapshot with
+                        # `stop_reason` still None if the SSE body ends prematurely after normal headers, contradictory
+                        # to SDK docstring for `stop_reason`. Move this case onto the existing retriable connection path.
+                        if resp.stop_reason is None:
+                            raise anthropic.APIConnectionError(
+                                message="client response message ended with stop_reason=None, against protocol.",
+                                request=stream.response.request,
+                            )
                         break
 
                 except (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netflux"
-version = "0.3.2"
+version = "0.3.3"
 maintainers = [
   { name="LW Computational Science Research Foundation" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,15 +38,15 @@ tui = [
 
 # Provider-specific dependencies
 anthropic = [
-    "anthropic>=0.79.0, <1.0.0",
+    "anthropic>=0.86.0, <1.0.0",
     "httpx[http2]",
 ]
 gemini = [
-    "google-genai>=1.56.0, <2.0.0",
+    "google-genai>=1.68.0, <2.0.0",
     "httpx[http2]",
 ]
-openai = ["openai>=1.109.1, <2.0.0"]
-xai = ["xai-sdk>=1.2.0, <2.0.0"]
+openai = ["openai>=2.29.0, <3.0.0"]
+xai = ["xai-sdk>=1.9.1, <2.0.0"]
 
 # A convenience group to install all provider clients
 # if running the demos or doing E2E integration tests.


### PR DESCRIPTION
Retry Incomplete Anthropic Streams With Missing stop_reason (rare corner case SDK protocol violation)

    - Anthropic SDK can occasionally return a final streamed Message with stop_reason=None after premature SSE EOF.
    - This violates the documented stop_reason contract: non-streaming Messages are non-null, and streamed Messages are null only in message_start.
    - We see it empirically in long-running tool/thinking loops even though it should not happen.
    - Treat it as APIConnectionError so it reuses the existing transient retry path.
    - Handle it immediately after get_final_message() before transcript/history/tool state mutates.