### PR TITLE
Node terminality implies subtree terminality; Various levels of enforcement; Terminal state immutability; SessionBag cleanup policy on node terminal (transitive closeability); Replace multiprocessing.* facilities with threading.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ This refined example shows:
     * `post_exception(exception: Exception)`: mark the current node as failed with given exception. If direct children are still running, the call blocks and the node remains in Running state until they are terminal.
     * `post_cancel()`: mark the current node as terminally canceled. If direct children are still running, the call blocks and the node remains in Running state until they are terminal.
     * `cancel_requested() -> bool`: helper to check whether the associated cancellation token has been triggered. This does not mean that the `Node` is already canceled and in canceled state -- it means there is active signaled *intention* to cancel.
+    * Thread-affinity rule: for a live node, only the main thread that entered the `CodeFunction` callable or the provider's `AgentNode.run()` may call `RunContext.invoke()` or any `RunContext.post_*()` method. Helper threads may do ordinary work, but must not touch those APIs and should be joined before the main thread returns, raises, or posts a terminal outcome.
 * Narrow Scope: `RunContext` is just a mechanism to pass on `Function` invocation directives to the `Runtime` to act on them.
 
 ## `Node`

--- a/README.md
+++ b/README.md
@@ -314,11 +314,11 @@ TUI(runtime).run()
 If you already have a top-level `Node` and just want to inspect that one tree, use `ConsoleRender` directly instead of writing your own watch loop:
 
 ```python
-import multiprocessing as mp
+import threading
 
 from netflux.tui import ConsoleRender
 
-cancel_evt = mp.Event()
+cancel_evt = threading.Event()
 node = ctx.invoke(top_level_fn, {...}, cancel_event=cancel_evt)
 render = ConsoleRender(spinner_hz=10.0)
 render.run(node)
@@ -332,7 +332,7 @@ For the standalone `ConsoleRender.run(node)` entrypoint, the top-level `Node` mu
 
 ## `SessionBag` & Objects
 
-In OOP, methods are functions that mutate an object’s state. netflux supports similar patterns with a **`SessionBag`**, a scoped object store with the **lifetime of a task** (and handy access to parent/root scopes). There are two important use cases in mind:
+In OOP, methods are functions that mutate an object’s state. netflux supports similar patterns with a **`SessionBag`**, an owned scoped object store with the **lifetime of a task** (and handy access to parent/root scopes). The framework enforces that a `Node` cannot actually enter a terminal state until its direct children are terminal, so in practice these bags remain valid until the relevant subtree is terminal. When the owning `Node` finally reaches terminal cleanup, the bag closes, rejects new entries, best-effort closes stored closeable objects, and drops its references. There are two important use cases in mind:
 
 * `Function`s can stash and retrieve objects to act like methods scoped to their parent or root ancestor. A good example of this is an agent that uses `bash` to perform its task, where it needs to persist a `BashSession` across command invocations (in this case, the `BashSession` is kept in the agent-scope `SessionBag` and the children invocations retrieve it).
 * `Function`s may use the `SessionBag` objects to pass input/output across sub‑tasks without serializing through text.
@@ -341,7 +341,7 @@ In OOP, methods are functions that mutate an object’s state. netflux supports 
 
 ## Concurrency (fan‑out)
 
-A task and its sub‑tasks form a **tree** where each node’s children are ordered by invocation (child edges record the call sequence). Like `Future`s, you can **launch multiple children in parallel** and defer collecting each `node.result()` until you’re ready to block. For `AgentFunction`s, this also works when the underlying model supports **parallel tool calling**.
+A task and its sub‑tasks form a **tree** where each node’s children are ordered by invocation (child edges record the call sequence). Like `Future`s, you can **launch multiple children in parallel** and defer collecting each `node.result()` until you’re ready to block. For `AgentFunction`s, this also works when the underlying model supports **parallel tool calling**. A callable or agent loop may determine its own success, exception, or cancellation before those children are terminal, but the framework will enforce that the node cannot actually *enter* a terminal state until its direct children are terminal. In that case the node remains in Running state and the terminalization call blocks until the children finish. By induction, if a node is terminal then its descendant subtree is terminal too; in particular, when a root node is done the entire tree is done. Once a node actually enters `Success`, `Error`, or `Canceled`, that terminal outcome is immutable. Authors should still explicitly wait on the children they launch where practical, because that is cleaner and makes handling child outputs, errors, and cancellation more deliberate.
 
 ---
 
@@ -367,14 +367,15 @@ See the detailed [Exception Model](#exception-model) below for guidance on when 
 
 ## Cooperative Cancellation
 
-**Cooperative Cancellation** uses cancellation token chaining, similar to that seen in languages like C# (`CancellationToken`s) and Go (`Context`s). For now we simply use `mp.Event` for these. Since tasks can be long-running, especially when they are agents, it's imperative to be able to timely interrupt entire trees or sub-trees to save resources when agents are not going in the desired direction or progress is not meeting time deadlines, and also just for responsive user experience.
+**Cooperative Cancellation** uses cancellation token chaining, similar to that seen in languages like C# (`CancellationToken`s) and Go (`Context`s). For now we simply use standard Python `Event` objects such as `threading.Event` for these. Since tasks can be long-running, especially when they are agents, it's imperative to be able to timely interrupt entire trees or sub-trees to save resources when agents are not going in the desired direction or progress is not meeting time deadlines, and also just for responsive user experience.
 
 By "cooperative", we refer to the pattern of cancellation chaining that requires framework consumers to properly adhere to the pattern in order to get the benefit. This means:
 
 * New `providers/` extensions (`AgentNode` subtypes) should check for cancellation at opportune times (before invoking children; before initial remote model invocation or before following up with function results). `AgentNode`s should `post_cancel()` in their agent loops and then simply exit the loop (return), or alternatively they can raise `cancellationException`. See `providers/anthropic.py` for an example.
 * `CodeFunction` callables should similarly be responsive to `self.is_cancel_requested()` and simply raise `cancellationException` as opportune times.
 * Always check for cancellation before invoking children tasks.
-* Always collect running children (e.g. block on each child `node.result()`) before responding to a cancellation request.
+* The framework will delay any terminal cancellation until direct children are terminal, so a node may remain in Running state while `post_cancel()` blocks waiting for its children to finish.
+* Even so, it is cleaner for authors to explicitly collect running children (e.g. block on each child `node.result()`) before responding to a cancellation request, because that keeps child outcomes part of normal control flow.
 * If an agent loop or callable is able to determine a success/exception outcome at or near the same time it would respond to cancellation, it should always prioritize concluding with success/exception instead of reacting to the cancellation request. This is because the work was done anyway, so you want the transcripts to show whatever was actually done at the time of cancellation.
 
 ---
@@ -574,11 +575,16 @@ This refined example shows:
     * `cancel_event: Optional[Event]`: cooperative cancellation token inherited from the caller unless explicitly overridden by the caller.
 * Methods:
     * `invoke(fn: Function, args: Dict[str, Any], provider: Optional[Provider] = None, cancel_event: Optional[Event] = None, tool_use_id: Optional[str] = None) -> Node`: invoke a `Function`, optionally overriding the cancellation scope, and return the created `Node`.
+        * Child invocations may be launched asynchronously and awaited later, but the Runtime will not allow the caller to enter a terminal state until its direct children are terminal. If the caller returns, raises, or posts any terminal outcome early, terminalization blocks while the node remains in Running state.
+        * Therefore, once a node is terminal, its descendant subtree is terminal too.
+        * Once the caller has actually entered a terminal state, further child invocations from it are rejected.
+        * It is still cleaner for authors to explicitly wait on the children they launch, because that keeps outputs/errors/cancellation handling deliberate.
         * `tool_use_id` is primarily for provider/framework internals to correlate agent transcript tool-call entries with created child nodes. Typical top-level and `CodeFunction` call sites should leave it as `None`.
-    * `post_status_update(state: NodeState)`: update the current node's status.
-    * `post_success(outputs: Any)`: mark the current node as successful with given outputs.
-    * `post_exception(exception: Exception)`: mark the current node as failed with given exception.
-    * `post_cancel()`: mark the current node as terminally canceled.
+    * `post_running()`: transition the current node from Waiting to Running. This is mainly for framework internals; repeated calls while already Running are a no-op, and calls after terminalization are ignored with an error log.
+    * Once a node actually reaches `Success`, `Error`, or `Canceled`, that terminal outcome is immutable; later terminal posts are logged and ignored.
+    * `post_success(outputs: Any)`: mark the current node as successful with given outputs. If direct children are still running, the call blocks and the node remains in Running state until they are terminal.
+    * `post_exception(exception: Exception)`: mark the current node as failed with given exception. If direct children are still running, the call blocks and the node remains in Running state until they are terminal.
+    * `post_cancel()`: mark the current node as terminally canceled. If direct children are still running, the call blocks and the node remains in Running state until they are terminal.
     * `cancel_requested() -> bool`: helper to check whether the associated cancellation token has been triggered. This does not mean that the `Node` is already canceled and in canceled state -- it means there is active signaled *intention* to cancel.
 * Narrow Scope: `RunContext` is just a mechanism to pass on `Function` invocation directives to the `Runtime` to act on them.
 
@@ -600,12 +606,14 @@ This refined example shows:
         * Always ordered to reflect the sequence in which `Function`s were invoked. 
         * For consumers outside the framework, use `NodeView.children: tuple[NodeView, ...]` instead to access child information safely.
     * Has states (Waiting, Running, Success, Error, Canceled) but also sub-state including tool use (`Function` invocation) that it is waiting on.
-    * `AgentNode` is completed once it returns final assistant text or the model decides to `RaiseException` (if it has been given as an option).
+    * An `AgentNode` may determine its own terminal outcome before its children do, but it does not actually enter a terminal state until its direct children are terminal (either cooperatively or by framework enforcement). While blocked on that boundary it remains in `Running`.
+    * Therefore, once an `AgentNode` is terminal, its descendant subtree is terminal too.
     * `TokenUsage` cumulative accounting must be reportable by every `AgentNode` and kept up to date throughout the agent loop (updated on every request/response iteration).
         * Subtype implementations must use the provider SDK's token usage meta to track the accumulation.
 * `CodeNode`: represents and manages the state and running of a `CodeFunction` invocation.
     * Simpler than `AgentFunction` because it is just a function call (unlike LLM session complexity). Authors invoke `Function`s directly from within the `Callable`.
-    * `CodeNode` is completed once it either returns or raises.
+    * A `CodeNode` may return or raise before its children finish, but it does not actually enter a terminal state until its direct children are terminal. While blocked on that boundary it remains in `Running`. It's recommended to explicitly wait on all children to finish before returning or raising, but the framework will enforce the terminalization order regardless.
+    * Therefore, once a `CodeNode` is terminal, its descendant subtree is terminal too.
 * Fields / Properties:
     * `id: int`: monotonically increasing unique identifier when Node is to be used as key in any lookup. This is one and the same as "task id".
     * `fn: Function`: which `Function` the `Node` is an instance of.
@@ -644,8 +652,10 @@ This refined example shows:
 ## `SessionBag`
 
 * Collection of arbitrary objects that may be read, mutated, and persisted by `Function`s.
-* Each `Node` created introduces a `SessionBag` with its lifetime. The `Node` and its children can access the bag.
+* Each `Node` created introduces a `SessionBag` that it owns for that node-scoped lifetime. The `Node` and its children can access the bag.
     * Thus, the `Node` can also access its parent's `SessionBag`, if it has a parent.
+    * While a callable is free to return, raise, or post a terminal outcome before its children are terminal, the framework will keep that `Node` in Running state and block terminalization until its direct children are terminal.
+    * This is why closing a `SessionBag` on `Node` terminal cleanup is safe: by the time the bag closes, the relevant subtree is already terminal.
 * Each `Node` can also access the `SessionBag` of the root `Node`.
 * `SessionScope`: enum of lifetime scopes, each of which would refer to a different `SessionBag` that a `Node` can access:
     * `TopLevel`: Lifetime envelopes all Nodes in a top-level tree. This would give the root `Node`'s bag.
@@ -667,9 +677,12 @@ This refined example shows:
         * To simplify, this is the only mechanism to be used by `Function`s for access. Concurrency-safe in case of parallel `Function` invocations. Simplify by invoking `factory` under the lock since not high-frequency.
         * `Function` implementations should cooperate to use descript namespaces and keys, composed of static string constants and instance numbers if multiplicity is possible.
     * `Runtime` is responsible for creating `SessionBag` with each `Node` and propagating references to new descendants.
-* Framework will currently rely on ref counting, garbage collection, and self-disposing object behavior (author responsibility).
-    * `Runtime` destruction, or explicit user request to delete a finished tree, will induce disposal of all `SessionBag`-referenced objects and their resources.
-    * This keeps objects alive long past their usable scope (potential resource leak), but is very worth the debuggability for finished subtrees. We can make this more configurable in the future (e.g. mandatory finalizers and dispose on `Node` completion).
+* `SessionBag` ownership is enforced by the framework at `Node` terminal cleanup.
+    * When a `Node` enters a terminal state, its `SessionBag` is closed.
+    * After closure, new `get_or_put()` attempts are rejected.
+    * Any owned objects with callable `close()` are closed transitively on a best-effort basis.
+    * Objects without `close()`, or whose `close()` fails, are still released because the bag drops its references.
+    * Because the Runtime delays terminalization until direct children are terminal, ancestor bags remain usable to descendants until the relevant subtree is done.
 
 ## Exception Model
 
@@ -729,6 +742,7 @@ This refined example shows:
     * A batch of parallel tool calls may result in 0, 1, or more of them succeeding or excepting and this is normal.
     * When a model issues a batch of tool calls and one of them is RaiseException (unusual), honor the model's intent and propagate `AgentException` to end the agent loop after the whole batch is attempted.
 * `CodeFunction` authors guidance:
+    * Prefer ordinary control flow for your own outcome: return a value for success and raise an `Exception` for failure.
     * Be aware that `Node.result()` from invoked functions may raise.
     * Ensure raisable `Exception`s from the Callable have descript type names and sufficient detail. If bubbling, sometimes this requires try-catch interception just to augment details (e.g. is the error pertaining to an input or output) and then re-raising.
     * Consider `AgentException`: may be difficult to handle statically; consider: retry, change provider. If repeatable, wrap attempts, augment context, and bubble up.
@@ -736,7 +750,7 @@ This refined example shows:
 * `AgentFunction` authors guidance:
     * Add the built-in `RaiseException` to the `AgentFunction.uses` property to enlist in `AgentException`s.
     * Provide additional guidance on when to raise, when to bubble up, (or how hard to retry alternatives first) in the system and user prompt. Iterate through trial and error. This will be very specific to the agent's purpose and scope.
-    * Strongly consider instructing the model to invoke `human_in_loop()` **before** considering `raise_exception()`.
+    * Consider instructing the model to invoke something like `human_in_loop()` **before** considering `raise_exception()`.
 
 ## `NodeView`
 
@@ -753,7 +767,7 @@ This refined example shows:
 
 - What triggers a new `NodeView`
   - Node creation and linking into the tree
-  - Status changes (`post_status_update`), success/exception/cancel
+  - Automatic transition to Running, plus success/exception/cancel
   - Transcript appends (agents call `post_transcript_update()` after each append)
 
 - Consistency model (origin-only live rebuild)

--- a/core.py
+++ b/core.py
@@ -255,10 +255,14 @@ class AgentFunction(Function):
     """
     Declarative specification for an LLM-backed Function.
 
-    Provider implementations may invoke child Functions while driving the agent loop. If the
-    agent determines its own outcome before those direct children finish, the Runtime keeps the
-    node in Running state until the children are terminal. Thus, once the agent node is terminal,
-    its descendant subtree is terminal too, and that terminal outcome is immutable.
+    Provider implementations may invoke child Functions while driving the agent loop. Only the
+    main thread that entered the provider's `run()` method may call `RunContext.invoke()` or any
+    `RunContext.post_*()` method, otherwise behavior is undefined; helper threads spawned by the
+    main thread must not touch those APIs.
+    
+    If the agent determines its own outcome before those direct children finish and does not wait on children,
+    the Runtime keeps the node in Running state until the children are terminal. Thus, once the
+    agent node is terminal, its descendant subtree is terminal too, and that terminal outcome is immutable.
     """
     def __init__(
         self,
@@ -296,11 +300,15 @@ class CodeFunction(Function):
     """
     Declarative specification for deterministic Python code executed with a RunContext.
 
-    Authors should prefer ordinary control flow: return a value for success and raise an
-    Exception for failure. If the callable launches child Functions and concludes before they do,
-    the Runtime keeps the node in Running state until its direct children are terminal. Thus, once
-    the code node is terminal, its descendant subtree is terminal too, and that terminal outcome
-    is immutable.
+    The callable's main invocation thread is the only thread that may call
+    `RunContext.invoke()` or any `RunContext.post_*()` method; helper threads spawned by the
+    main thread must not touch those APIs, otherwise the behavior is undefined.
+    
+    Authors should prefer ordinary control flow: return a value for success and raise
+    an Exception for failure. If the callable launches child Functions and does not wait on them
+    all, the Runtime keeps the node in Running state until its direct children are terminal. Thus,
+    once the code node is terminal, its descendant subtree is terminal too, and that terminal
+    outcome is immutable.
     """
     def __init__(
         self,
@@ -683,7 +691,9 @@ class CodeNode(Node):
     explicitly wait on the children they launch where practical, because that is
     cleaner and keeps child results/errors part of normal control flow.
     
-    Authors must not use `RunContext` from a different thread otherwise behavior is undefined.
+    Only the main thread executing the Callable may use `RunContext.invoke()` and
+    `RunContext.post_*()`. Helper threads must not touch those APIs, and should be joined before
+    the Callable returns, raises, or posts a terminal outcome.
     """
     def __init__(
         self,
@@ -719,6 +729,10 @@ class AgentNode(Node):
     use the `RunContext` to submit children `Function` calls as a result of tool use.
     Before returning from `run()`, they should use `self.ctx.post_success()`, `self.ctx.post_exception()`,
     or `self.ctx.post_cancel()`.
+
+    Only the main thread that entered `run()` may call `RunContext.invoke()` or any
+    `RunContext.post_*()` method. Helper threads must not touch those APIs, and should be joined
+    before `run()` returns, raises, or posts a terminal outcome.
 
     The Runtime will block terminalization if, and as long as, direct children are still running,
     but provider implementations should still explicitly wait on the children they launch because

--- a/core.py
+++ b/core.py
@@ -425,14 +425,6 @@ class RunContext:
         Proxy to the Runtime to invoke a Function and create associated Node + edges.
         Returns the created `Node`.
 
-        Child Nodes may be launched and then awaited later, but the Runtime enforces that this
-        caller cannot actually enter a terminal state until its direct children are terminal. This
-        means terminalization may block while the caller remains in Running state. Authors should
-        still explicitly wait on launched children where practical, because that keeps handling of
-        child outputs, exceptions, and cancellation more deliberate and easier to reason about.
-        Once the caller has actually entered a terminal state, further child invocations from it
-        are rejected by the Runtime.
-
         For AgentFunction calls only, optionally specify `provider` to override the default model.
 
         Provide `cancel_event` to enforce a particular cancellation scope for the child node.

--- a/core.py
+++ b/core.py
@@ -3,18 +3,19 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Type, Union, get_args, Mapping
 import inspect
-from threading import Thread
-import multiprocessing as mp
-from multiprocessing import Lock
-from multiprocessing.synchronize import Event
+import logging
+from threading import Event, Lock, Thread
 from overrides import override
+
+from .providers import Provider
 
 AllowedArgTypeUnion = Union[Type[str], Type[int], Type[float], Type[bool]]
 AllowedArgTypeTuple: tuple[type, ...] = tuple(
     inner for t in get_args(AllowedArgTypeUnion) for inner in get_args(t)
 )
 
-from .providers import Provider
+
+logger = logging.getLogger(__name__)
 
 class CancellationException(Exception):
     """Raised when a node cooperatively acknowledges a cancellation request."""
@@ -76,19 +77,60 @@ class TokenBill:
     output_tokens_total: int = 0
 
 class SessionBag:
-    """Thread-safe namespace/key object registry for a Node scope."""
+    """
+    Thread-safe namespace/key object registry owned by a single Node scope.
+
+    A SessionBag owns the lifecycle of the objects stored within it. `close()` is idempotent,
+    causes rejection of future `get_or_put()` calls, and transitively calls `close()` on each
+    closeable stored object, and then drops all remaining references even if some cleanup
+    failed or some objects are not closeable (so garbage collection finishes the cleanup).
+
+    The Runtime enforces that a Node cannot enter terminal state until its direct children have,
+    so ancestor SessionBags remain valid for descendants until the relevant subtree is terminal.
+    """
     def __init__(self) -> None:
         self._lock = Lock()
         self._values: Dict[str, Dict[str, Any]] = {}
+        self._closed: bool = False
 
     def get_or_put(self, namespace: str, key: str, factory: Callable[[], Any]) -> Any:
         with self._lock:
+            if self._closed:
+                raise RuntimeError("SessionBag is terminally closed")
             ns = self._values.setdefault(namespace, {})
             if key in ns:
                 return ns[key]
             value = factory()
             ns[key] = value
             return value
+
+    def close(self) -> None:
+        """Idempotently close the bag and release all owned references."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            values = self._values
+            self._values = {}
+
+        # Get all the unique object references in the bag with de-dup in case the same object was
+        # under multiple keys/namespaces (uncommon).
+        unique_objs: List[Any] = {
+            id(value): value for ns in values.values() for value in ns.values()
+        }.values()
+
+        # The assumption remains that the SessionBag is the sole parent container of these objects
+        # and owns their lifecycle, so should transitively close() all such owned objects.
+        for obj in unique_objs:
+            close = getattr(obj, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    logger.exception(
+                        f"SessionBag: close() failed for owned object {obj!r}. "
+                        "However, it will be subject to GC.",
+                    )
 
 @dataclass(frozen=True)
 class FunctionArg:
@@ -210,6 +252,14 @@ class Function(ABC):
         return isinstance(self, CodeFunction)
 
 class AgentFunction(Function):
+    """
+    Declarative specification for an LLM-backed Function.
+
+    Provider implementations may invoke child Functions while driving the agent loop. If the
+    agent determines its own outcome before those direct children finish, the Runtime keeps the
+    node in Running state until the children are terminal. Thus, once the agent node is terminal,
+    its descendant subtree is terminal too, and that terminal outcome is immutable.
+    """
     def __init__(
         self,
         *,
@@ -243,6 +293,15 @@ class AgentFunction(Function):
         return list(self.uses_funcs)
 
 class CodeFunction(Function):
+    """
+    Declarative specification for deterministic Python code executed with a RunContext.
+
+    Authors should prefer ordinary control flow: return a value for success and raise an
+    Exception for failure. If the callable launches child Functions and concludes before they do,
+    the Runtime keeps the node in Running state until its direct children are terminal. Thus, once
+    the code node is terminal, its descendant subtree is terminal too, and that terminal outcome
+    is immutable.
+    """
     def __init__(
         self,
         *,
@@ -366,6 +425,14 @@ class RunContext:
         Proxy to the Runtime to invoke a Function and create associated Node + edges.
         Returns the created `Node`.
 
+        Child Nodes may be launched and then awaited later, but the Runtime enforces that this
+        caller cannot actually enter a terminal state until its direct children are terminal. This
+        means terminalization may block while the caller remains in Running state. Authors should
+        still explicitly wait on launched children where practical, because that keeps handling of
+        child outputs, exceptions, and cancellation more deliberate and easier to reason about.
+        Once the caller has actually entered a terminal state, further child invocations from it
+        are rejected by the Runtime.
+
         For AgentFunction calls only, optionally specify `provider` to override the default model.
 
         Provide `cancel_event` to enforce a particular cancellation scope for the child node.
@@ -386,17 +453,29 @@ class RunContext:
             tool_use_id=tool_use_id,
         )
 
-    def post_status_update(self, state: 'NodeState') -> None:
+    def post_running(self) -> None:
         if self.node is None:
-            raise RuntimeError("post_status_update may only be called from within a Node execution context")
-        self.runtime.post_status_update(self.node, state)
+            raise RuntimeError("post_running may only be called from within a Node execution context")
+        self.runtime.post_running(self.node)
 
     def post_success(self, outputs: Any) -> None:
+        """
+        Mark the current node as successful with the given outputs.
+
+        If the node still has direct children running, the Runtime will block here and keep the
+        node in Running state until those children have terminated.
+        """
         if self.node is None:
             raise RuntimeError("post_success may only be called from within a Node execution context")
         self.runtime.post_success(self.node, outputs)
 
     def post_exception(self, exception: Exception) -> None:
+        """
+        Mark the current node as failed with the given exception.
+
+        If the node still has direct children running, the Runtime will block here and keep the
+        node in Running state until those children have terminated.
+        """
         if self.node is None:
             raise RuntimeError("post_exception may only be called from within a Node execution context")
         self.runtime.post_exception(self.node, exception)
@@ -406,6 +485,9 @@ class RunContext:
         Inform the Runtime that the current Node is being cooperatively canceled.
         The `exception` may be provided to indicate the reason for cancellation,
         otherwise a generic `CancellationException` will be used.
+
+        If the node still has direct children running, the Runtime will block here and keep the
+        node in Running state until those children have terminated.
         """
         if self.node is None:
             raise RuntimeError("post_cancel may only be called from within a Node execution context")
@@ -513,7 +595,7 @@ class Node(ABC):
         self.parent: Optional[Node] = parent
         self.children: List[Node] = []
         self.thread: Optional[Thread] = None
-        self.done: Event = mp.Event()
+        self.done: Event = Event()
         self.session_bag: SessionBag = SessionBag()
         self.cancel_event: Optional[Event] = cancel_event
         self.started_at: Optional[float] = None
@@ -535,7 +617,7 @@ class Node(ABC):
         self.thread.start()
 
     def run_wrapper(self) -> None:
-        self.ctx.post_status_update(NodeState.Running)
+        self.ctx.post_running()
 
         try:
             self.run()
@@ -545,6 +627,7 @@ class Node(ABC):
             self.ctx.post_exception(ex)
         assert self.state in TerminalNodeStates
         assert self.done.is_set()
+        self.on_terminal_cleanup()
 
     @abstractmethod
     def run(self) -> None:
@@ -580,6 +663,9 @@ class Node(ABC):
             return False
         return self.cancel_event.is_set()
 
+    def on_terminal_cleanup(self) -> None:
+        self.session_bag.close()
+
 class CodeNode(Node):
     """
     The invoked CodeFunction is expected to expose a Python callable under the attribute
@@ -594,6 +680,18 @@ class CodeNode(Node):
     A caller will typically call `node.result()` to wait for completion and get the
     output string. Alternatively, the Callable may raise an Exception, which will be
     propagated upon calling `node.result()`.
+
+    If the Callable explicitly posts a terminal outcome itself via `self.ctx.post_*()`,
+    and then later returns or raises, the later return/exception is ignored. Thus, authors
+    are encouraged to use return value or exception for signaling the outcome.
+
+    If the Callable launches children and then returns or raises before those children
+    are terminal, the Runtime will keep this node in Running state and block its
+    terminalization until its direct children are terminal. Authors should still
+    explicitly wait on the children they launch where practical, because that is
+    cleaner and keeps child results/errors part of normal control flow.
+    
+    Authors must not use `RunContext` from a different thread otherwise behavior is undefined.
     """
     def __init__(
         self,
@@ -610,9 +708,8 @@ class CodeNode(Node):
 
     def run(self) -> None:
         assert isinstance(self.fn, CodeFunction)
-        func: CodeFunction = self.fn
         try:
-            result = func.callable(self.ctx, **self.inputs)
+            result = self.fn.callable(self.ctx, **self.inputs)
             self.ctx.post_success(result)
         except CancellationException as e:
             self.ctx.post_cancel(e)
@@ -628,7 +725,12 @@ class AgentNode(Node):
 
     Subclasses must implement `run()` to drive a provider-specific tool loop, and therein
     use the `RunContext` to submit children `Function` calls as a result of tool use.
-    Before returning from `run()`, they should have set `self.outputs` or `self.exception`.
+    Before returning from `run()`, they should use `self.ctx.post_success()`, `self.ctx.post_exception()`,
+    or `self.ctx.post_cancel()`.
+
+    The Runtime will block terminalization if, and as long as, direct children are still running,
+    but provider implementations should still explicitly wait on the children they launch because
+    it is cleaner and keeps transcript/error handling deliberate.
     """
     def __init__(
         self,
@@ -669,7 +771,7 @@ class AgentNode(Node):
 
     @override
     def run_wrapper(self) -> None:
-        self.ctx.post_status_update(NodeState.Running)
+        self.ctx.post_running()
         try:
             self.run()
         except AgentException as e:
@@ -692,6 +794,7 @@ class AgentNode(Node):
             self.ctx.post_exception(mpe)
         assert self.state in TerminalNodeStates
         assert self.done.is_set()
+        self.on_terminal_cleanup()
 
     def build_user_text(self) -> str:
         # Templated user prompt injection.

--- a/func_lib/bash_func.py
+++ b/func_lib/bash_func.py
@@ -163,6 +163,18 @@ class BashSession:
         self._drain_queue_nowait()
         self.start()
 
+    def close(self) -> None:
+        self._terminate_group_if_alive()
+        try:
+            if self._stdout_thread is not None:
+                self._stdout_thread.join(timeout=0.25)
+        except Exception:
+            pass
+        self._stdout_thread = None
+        self._drain_queue_nowait()
+        self.requires_restart = False
+        self._alive_once_started = False
+
     def alive(self) -> bool:
         return self._proc is not None and self._proc.poll() is None
 

--- a/func_lib/text_editor_func.py
+++ b/func_lib/text_editor_func.py
@@ -11,17 +11,6 @@ from ..core import FunctionArg, CodeFunction, RunContext, SessionScope
 class TextEditorException(Exception):
     """Raised for business-logic violations in the TextEditor tool."""
 
-
-class _FileLock:
-    def __init__(self) -> None:
-        self._lock = Lock()
-
-    def acquire(self, *args, **kwargs):
-        return self._lock.acquire(*args, **kwargs)
-
-    def release(self) -> None:
-        self._lock.release()
-
 class TextEditor(CodeFunction):
     """
     A text editor tool for reading and modifying files inspired by and aligned with Anthropic's
@@ -148,7 +137,7 @@ class TextEditor(CodeFunction):
             SessionScope.TopLevel,
             namespace=self._FILE_LOCK_NAMESPACE,
             key=self._file_lock_key(p),
-            factory=_FileLock,
+            factory=Lock,
         )
 
     def handle_view(

--- a/func_lib/text_editor_func.py
+++ b/func_lib/text_editor_func.py
@@ -1,15 +1,26 @@
 from pathlib import Path
-from multiprocessing import Lock
 import tempfile
 import os
 import re
 import secrets
+from threading import Lock
 from typing import Set, Optional
 
 from ..core import FunctionArg, CodeFunction, RunContext, SessionScope
 
 class TextEditorException(Exception):
     """Raised for business-logic violations in the TextEditor tool."""
+
+
+class _FileLock:
+    def __init__(self) -> None:
+        self._lock = Lock()
+
+    def acquire(self, *args, **kwargs):
+        return self._lock.acquire(*args, **kwargs)
+
+    def release(self) -> None:
+        self._lock.release()
 
 class TextEditor(CodeFunction):
     """
@@ -137,7 +148,7 @@ class TextEditor(CodeFunction):
             SessionScope.TopLevel,
             namespace=self._FILE_LOCK_NAMESPACE,
             key=self._file_lock_key(p),
-            factory=Lock,
+            factory=_FileLock,
         )
 
     def handle_view(

--- a/providers/anthropic.py
+++ b/providers/anthropic.py
@@ -168,8 +168,14 @@ class AnthropicAgentNode(AgentNode):
         return Provider.Anthropic
 
     def _close_client(self) -> None:
-        self.client.close()
-        self.client = None  # type: ignore[assignment]
+        if self.client is None:
+            return
+        try:
+            self.client.close()
+        except Exception:
+            pass
+        finally:
+            self.client = None  # type: ignore[assignment]
 
     def run(self) -> None:
         # Agent loop.

--- a/providers/anthropic.py
+++ b/providers/anthropic.py
@@ -1,10 +1,9 @@
 from types import SimpleNamespace, MappingProxyType
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Union, cast
 import copy
-import logging
+from threading import Event
 import time
 import random
-from threading import Event
 from overrides import override
 
 from ..core import (
@@ -31,9 +30,6 @@ from anthropic.types import (
 
 )
 from anthropic.types.tool_param import InputSchemaTyped
-
-
-logger = logging.getLogger(__name__)
 
 """
 ## Misc Research Notes (applicable to Claude 4 models)
@@ -171,11 +167,16 @@ class AnthropicAgentNode(AgentNode):
     def provider(self) -> Provider:
         return Provider.Anthropic
 
+    def _close_client(self) -> None:
+        self.client.close()
+        self.client = None  # type: ignore[assignment]
+
     def run(self) -> None:
         # Agent loop.
         for _ in range(MAX_STEPS):
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
+                self._close_client()
                 return
 
             # Apply watermark to *latest* user message only (just-in-time).
@@ -243,10 +244,12 @@ class AnthropicAgentNode(AgentNode):
                         is_connection = True
                     
                     if not is_retriable or attempt >= max_attempts:
+                        self._close_client()
                         raise
 
                     if self.is_cancel_requested():
                         self.ctx.post_cancel()
+                        self._close_client()
                         return
 
                     delay = base_delay * (2 ** (attempt - 1))
@@ -258,13 +261,14 @@ class AnthropicAgentNode(AgentNode):
                     if self.cancel_event:
                         if self.cancel_event.wait(delay):
                             self.ctx.post_cancel()
+                            self._close_client()
                             return
                     else:
                         time.sleep(delay)
 
                     # Rebuild client on transport errors to reset broken sessions/sockets.
                     if is_connection:
-                        self.client.close()
+                        self._close_client()
                         self.client = self.client_factory()
 
                     attempt += 1
@@ -272,6 +276,7 @@ class AnthropicAgentNode(AgentNode):
 
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
+                self._close_client()
                 return
 
             # Incremental token accounting.
@@ -335,6 +340,7 @@ class AnthropicAgentNode(AgentNode):
                 # Assert expectation that the protocol is the way we think:
                 # model is finishing the turn with final text completion.
                 if resp.stop_reason != "end_turn":
+                    self._close_client()
                     raise ModelProviderException(
                         message=f"Expected stop_reason 'end_turn' for final text, got "
                                 f"'{resp.stop_reason!r}'; debug protocol adherence.",
@@ -347,16 +353,19 @@ class AnthropicAgentNode(AgentNode):
                 self.transcript.append(ModelTextPart(text=final_text))
                 self.ctx.post_transcript_update()
                 self.ctx.post_success(final_text)
+                self._close_client()
                 return
 
             # Make sure we check for cancellation right before commencing possibly
             # lengthy sub-tasks.
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
+                self._close_client()
                 return
 
             # Assert expectation: model requested tool use in this turn.
             if resp.stop_reason != "tool_use":
+                self._close_client()
                 raise ModelProviderException(
                     message=f"Expected stop_reason 'tool_use' before tool execution, got "
                             f"'{resp.stop_reason!r}'; debug protocol adherence.",
@@ -433,14 +442,17 @@ class AnthropicAgentNode(AgentNode):
             # order of priority.
             if pending_agent_ex:
                 self.ctx.post_exception(pending_agent_ex)
+                self._close_client()
                 return
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
+                self._close_client()
                 return
             
             # Per protocol: next user message contains only tool_result blocks
             self._history.append(cast(MessageParam, {"role": "user", "content": result_blocks}))
 
+        self._close_client()
         raise RuntimeError(f"Anthropic agent loop exceeded MAX_STEPS ({MAX_STEPS}) "
                            "without producing a final response.")
 
@@ -553,12 +565,3 @@ class AnthropicAgentNode(AgentNode):
         if py_t is float: return "number"
         if py_t is bool:  return "boolean"
         return "string"  # fallback
-
-    @override
-    def on_terminal_cleanup(self) -> None:
-        try:
-            self.client.close()
-        except Exception:
-            logger.exception("Anthropic client cleanup failed for node %s", self.id)
-        self.client = None  # type: ignore[assignment]
-        super().on_terminal_cleanup()

--- a/providers/anthropic.py
+++ b/providers/anthropic.py
@@ -1,9 +1,10 @@
 from types import SimpleNamespace, MappingProxyType
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Union, cast
 import copy
-from multiprocessing.synchronize import Event
+import logging
 import time
 import random
+from threading import Event
 from overrides import override
 
 from ..core import (
@@ -30,6 +31,9 @@ from anthropic.types import (
 
 )
 from anthropic.types.tool_param import InputSchemaTyped
+
+
+logger = logging.getLogger(__name__)
 
 """
 ## Misc Research Notes (applicable to Claude 4 models)
@@ -172,7 +176,6 @@ class AnthropicAgentNode(AgentNode):
         for _ in range(MAX_STEPS):
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
-                self.client.close()
                 return
 
             # Apply watermark to *latest* user message only (just-in-time).
@@ -244,7 +247,6 @@ class AnthropicAgentNode(AgentNode):
 
                     if self.is_cancel_requested():
                         self.ctx.post_cancel()
-                        self.client.close()
                         return
 
                     delay = base_delay * (2 ** (attempt - 1))
@@ -256,7 +258,6 @@ class AnthropicAgentNode(AgentNode):
                     if self.cancel_event:
                         if self.cancel_event.wait(delay):
                             self.ctx.post_cancel()
-                            self.client.close()
                             return
                     else:
                         time.sleep(delay)
@@ -271,7 +272,6 @@ class AnthropicAgentNode(AgentNode):
 
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
-                self.client.close()
                 return
 
             # Incremental token accounting.
@@ -347,14 +347,12 @@ class AnthropicAgentNode(AgentNode):
                 self.transcript.append(ModelTextPart(text=final_text))
                 self.ctx.post_transcript_update()
                 self.ctx.post_success(final_text)
-                self.client.close()
                 return
 
             # Make sure we check for cancellation right before commencing possibly
             # lengthy sub-tasks.
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
-                self.client.close()
                 return
 
             # Assert expectation: model requested tool use in this turn.
@@ -435,11 +433,9 @@ class AnthropicAgentNode(AgentNode):
             # order of priority.
             if pending_agent_ex:
                 self.ctx.post_exception(pending_agent_ex)
-                self.client.close()
                 return
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
-                self.client.close()
                 return
             
             # Per protocol: next user message contains only tool_result blocks
@@ -557,3 +553,12 @@ class AnthropicAgentNode(AgentNode):
         if py_t is float: return "number"
         if py_t is bool:  return "boolean"
         return "string"  # fallback
+
+    @override
+    def on_terminal_cleanup(self) -> None:
+        try:
+            self.client.close()
+        except Exception:
+            logger.exception("Anthropic client cleanup failed for node %s", self.id)
+        self.client = None  # type: ignore[assignment]
+        super().on_terminal_cleanup()

--- a/providers/gemini.py
+++ b/providers/gemini.py
@@ -2,9 +2,10 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from types import MappingProxyType
 import copy
 import base64
+import logging
 import time
 import random
-from multiprocessing.synchronize import Event
+from threading import Event
 import httpx
 from overrides import override
 
@@ -18,6 +19,9 @@ from . import ModelNames, Provider
 import google.genai as genai
 from google.genai import types
 from google.genai import errors as genai_errors
+
+
+logger = logging.getLogger(__name__)
 
 """
 ## Misc Research Notes.
@@ -159,7 +163,6 @@ class GeminiAgentNode(AgentNode):
         for _ in range(MAX_STEPS):
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
-                self.client.close()
                 return
 
             # One thinking-tool turn.
@@ -239,7 +242,6 @@ class GeminiAgentNode(AgentNode):
 
                     if self.is_cancel_requested():
                         self.ctx.post_cancel()
-                        self.client.close()
                         return
 
                     delay = base_delay * (2 ** (attempt - 1))
@@ -251,7 +253,6 @@ class GeminiAgentNode(AgentNode):
                     if self.cancel_event:
                         if self.cancel_event.wait(delay):
                             self.ctx.post_cancel()
-                            self.client.close()
                             return
                     else:
                         time.sleep(delay)
@@ -266,7 +267,6 @@ class GeminiAgentNode(AgentNode):
             
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
-                self.client.close()
                 return
 
             # Incremental token accounting.
@@ -284,7 +284,6 @@ class GeminiAgentNode(AgentNode):
                 # No new content and we are done.
                 # Finalize with whatever is in the transcript.
                 self.ctx.post_success(self._final_text())
-                self.client.close()
                 return
             
             # Thoughts are supposed to be empty (hidden) or we want to know of API change.
@@ -326,7 +325,6 @@ class GeminiAgentNode(AgentNode):
                 assert candidate.finish_reason == types.FinishReason.STOP, (
                     "Expected finish_reason=STOP when no function calls")
                 self.ctx.post_success(self._final_text())
-                self.client.close()
                 return
 
             # At this point, there are function calls to process. First, sanity check:
@@ -337,7 +335,6 @@ class GeminiAgentNode(AgentNode):
             # lengthy sub-tasks.
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
-                self.client.close()
                 return
 
             # Execute requested tools in parallel and aggregate all function responses.
@@ -425,11 +422,9 @@ class GeminiAgentNode(AgentNode):
             # order of priority.
             if pending_agent_ex:
                 self.ctx.post_exception(pending_agent_ex)
-                self.client.close()
                 return
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
-                self.client.close()
                 return
             
             # Per protocol: next user message contains only function results.
@@ -532,3 +527,12 @@ class GeminiAgentNode(AgentNode):
         if py_t is float: return types.Type.NUMBER
         if py_t is bool:  return types.Type.BOOLEAN
         return types.Type.STRING
+
+    @override
+    def on_terminal_cleanup(self) -> None:
+        try:
+            self.client.close()
+        except Exception:
+            logger.exception("Gemini client cleanup failed for node %s", self.id)
+        self.client = None  # type: ignore[assignment]
+        super().on_terminal_cleanup()

--- a/providers/gemini.py
+++ b/providers/gemini.py
@@ -2,7 +2,6 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from types import MappingProxyType
 import copy
 import base64
-import logging
 import time
 import random
 from threading import Event
@@ -19,9 +18,6 @@ from . import ModelNames, Provider
 import google.genai as genai
 from google.genai import types
 from google.genai import errors as genai_errors
-
-
-logger = logging.getLogger(__name__)
 
 """
 ## Misc Research Notes.
@@ -140,6 +136,10 @@ class GeminiAgentNode(AgentNode):
         self._tool_call_counter += 1
         return f"gemini-{self.id}-{self._tool_call_counter}-{tool_name}"
 
+    def _close_client(self) -> None:
+        self.client.close()
+        self.client = None  # type: ignore[assignment]
+
     def run(self) -> None:
         config = types.GenerateContentConfig(
             system_instruction=self.agent_fn.system_prompt,
@@ -163,6 +163,7 @@ class GeminiAgentNode(AgentNode):
         for _ in range(MAX_STEPS):
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
+                self._close_client()
                 return
 
             # One thinking-tool turn.
@@ -238,10 +239,12 @@ class GeminiAgentNode(AgentNode):
                         is_retriable = True
 
                     if not is_retriable or attempt >= max_attempts:
+                        self._close_client()
                         raise
 
                     if self.is_cancel_requested():
                         self.ctx.post_cancel()
+                        self._close_client()
                         return
 
                     delay = base_delay * (2 ** (attempt - 1))
@@ -253,13 +256,14 @@ class GeminiAgentNode(AgentNode):
                     if self.cancel_event:
                         if self.cancel_event.wait(delay):
                             self.ctx.post_cancel()
+                            self._close_client()
                             return
                     else:
                         time.sleep(delay)
 
                     # Rebuild client on transport errors to reset broken sessions/sockets.
                     if is_connection:
-                        self.client.close()
+                        self._close_client()
                         self.client = self.client_factory()
 
                     attempt += 1
@@ -267,6 +271,7 @@ class GeminiAgentNode(AgentNode):
             
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
+                self._close_client()
                 return
 
             # Incremental token accounting.
@@ -284,6 +289,7 @@ class GeminiAgentNode(AgentNode):
                 # No new content and we are done.
                 # Finalize with whatever is in the transcript.
                 self.ctx.post_success(self._final_text())
+                self._close_client()
                 return
             
             # Thoughts are supposed to be empty (hidden) or we want to know of API change.
@@ -325,6 +331,7 @@ class GeminiAgentNode(AgentNode):
                 assert candidate.finish_reason == types.FinishReason.STOP, (
                     "Expected finish_reason=STOP when no function calls")
                 self.ctx.post_success(self._final_text())
+                self._close_client()
                 return
 
             # At this point, there are function calls to process. First, sanity check:
@@ -335,6 +342,7 @@ class GeminiAgentNode(AgentNode):
             # lengthy sub-tasks.
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
+                self._close_client()
                 return
 
             # Execute requested tools in parallel and aggregate all function responses.
@@ -422,15 +430,18 @@ class GeminiAgentNode(AgentNode):
             # order of priority.
             if pending_agent_ex:
                 self.ctx.post_exception(pending_agent_ex)
+                self._close_client()
                 return
             if self.is_cancel_requested():
                 self.ctx.post_cancel()
+                self._close_client()
                 return
             
             # Per protocol: next user message contains only function results.
             # Aggregated function results to single Content message.
             self._history.append(types.Content(role="tool", parts=result_parts))
 
+        self._close_client()
         raise RuntimeError(f"Gemini agent loop exceeded MAX_STEPS ({MAX_STEPS}) "
                            "without producing a final response.")
 
@@ -527,12 +538,3 @@ class GeminiAgentNode(AgentNode):
         if py_t is float: return types.Type.NUMBER
         if py_t is bool:  return types.Type.BOOLEAN
         return types.Type.STRING
-
-    @override
-    def on_terminal_cleanup(self) -> None:
-        try:
-            self.client.close()
-        except Exception:
-            logger.exception("Gemini client cleanup failed for node %s", self.id)
-        self.client = None  # type: ignore[assignment]
-        super().on_terminal_cleanup()

--- a/providers/gemini.py
+++ b/providers/gemini.py
@@ -137,8 +137,14 @@ class GeminiAgentNode(AgentNode):
         return f"gemini-{self.id}-{self._tool_call_counter}-{tool_name}"
 
     def _close_client(self) -> None:
-        self.client.close()
-        self.client = None  # type: ignore[assignment]
+        if self.client is None:
+            return
+        try:
+            self.client.close()
+        except Exception:
+            pass
+        finally:
+            self.client = None  # type: ignore[assignment]
 
     def run(self) -> None:
         config = types.GenerateContentConfig(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netflux"
-version = "0.3.3"
+version = "0.3.4"
 maintainers = [
   { name="LW Computational Science Research Foundation" },
 ]

--- a/runtime.py
+++ b/runtime.py
@@ -214,7 +214,11 @@ class Runtime:
            
             self._publish_viewtree_update(node)
 
-        node.start()
+        try:
+            node.start()
+        except Exception as ex:
+            node.thread = None
+            self.post_exception(node, ex)
         return node
 
     def _build_session_bags(self, node: Node) -> Dict[SessionScope, SessionBag]:
@@ -450,6 +454,7 @@ class Runtime:
 
     def post_success(self, node: Node, outputs: Any) -> None:
         self.wait_for_children_finished(node)
+        node.on_terminal_cleanup()
 
         with self._lock:
             if node.state in TerminalNodeStates:
@@ -470,6 +475,7 @@ class Runtime:
 
     def post_exception(self, node: Node, exception: Exception) -> None:
         self.wait_for_children_finished(node)
+        node.on_terminal_cleanup()
         
         with self._lock:
             if node.state in TerminalNodeStates:
@@ -501,6 +507,7 @@ class Runtime:
         otherwise the Node is assigned a no-reason CancellationException.
         """
         self.wait_for_children_finished(node)
+        node.on_terminal_cleanup()
 
         with self._lock:
             if node.state in TerminalNodeStates:
@@ -522,5 +529,12 @@ class Runtime:
     def post_transcript_update(self, node: Node) -> None:
         """Called by a Node when its transcript changed and a new NodeView snapshot should be published."""
         with self._lock:
+            if node.state in TerminalNodeStates:
+                logger.error(
+                    "Ignoring post_transcript_update for terminal node %s (%s); "
+                    "it has no effect and is ignored.",
+                    node.id, node.fn.name,
+                )
+                return
             self._global_seqno += 1
             self._publish_viewtree_update(node)

--- a/runtime.py
+++ b/runtime.py
@@ -4,12 +4,10 @@ import logging
 import time
 from types import MappingProxyType
 from typing import Any, Callable, Deque, Dict, List, Mapping, Optional, Sequence, Union
-import multiprocessing as mp
-from multiprocessing import Lock
-from multiprocessing.synchronize import Event, Condition
 from collections import deque
 import os
 import threading
+from threading import Condition, Event, Lock
 
 from .core import (
     Node,
@@ -24,6 +22,7 @@ from .core import (
     SessionScope,
     SessionBag,
     CancellationException,
+    TerminalNodeStates,
     TokenUsage,
     ToolUsePart,
     ToolResultPart,
@@ -156,6 +155,11 @@ class Runtime:
         inputs = fn.validate_coerce_args(inputs)
 
         with self._lock:
+            if caller is not None and caller.state in TerminalNodeStates:
+                raise RuntimeError(
+                    f"Cannot invoke child function '{fn.name}' from terminal node "
+                    f"{caller.id} ({caller.fn.name})."
+                )
             node_id = self._next_node_id
             self._next_node_id += 1
 
@@ -198,7 +202,7 @@ class Runtime:
 
             self._nodes_by_id[node_id] = node
             self._node_observables[node_id] = NodeObservable(
-                cond=mp.Condition(self._lock),
+                cond=Condition(self._lock),
                 touch_seqno=self._global_seqno,
                 view=self._build_node_view(node),
             )
@@ -406,17 +410,56 @@ class Runtime:
             return node.id
         return node
 
-    def post_status_update(self, node: Node, state: NodeState) -> None:
+    def post_running(self, node: Node) -> None:
         with self._lock:
+            if node.state is NodeState.Running:
+                return
+            if node.state in TerminalNodeStates:
+                logger.error(
+                    "Ignoring post_running for already-terminal node %s (%s); "
+                    "it shall have no effect and is ignored.",
+                    node.id, node.fn.name,
+                )
+                return
+            assert node.state is NodeState.Waiting, (
+                f"Unexpected node state for post_running: {node.state.value}"
+            )
+            
             self._global_seqno += 1
-            # Record start time on first transition to Running
-            if state is NodeState.Running and not node.started_at:
+            if not node.started_at:
                 node.started_at = time.time()
-            node.state = state
+            node.state = NodeState.Running
             self._publish_viewtree_update(node)
 
-    def post_success(self, node: Node, outputs: Any) -> None:
+    def wait_for_children_finished(self, node: Node) -> None:
+        """
+        Block until all direct children of `node` are in terminal states
+        and also totally non-runnable going forward.
+
+        The runtime enforces this before allowing a node to enter any terminal state.
+        Because every child is subject to the same rule before it can become terminal,
+        waiting for direct children is sufficient by induction to imply the entire
+        descendant subtree is terminal when this returns.
+        """
         with self._lock:
+            children = tuple(node.children)
+        for child in children:
+            child.done.wait()
+            if child.thread is not None:
+                child.thread.join()
+
+    def post_success(self, node: Node, outputs: Any) -> None:
+        self.wait_for_children_finished(node)
+
+        with self._lock:
+            if node.state in TerminalNodeStates:
+                logger.error(
+                    "Ignoring post_success for terminal node %s (%s); transition from %s "
+                    "to %s has no effect and is ignored.",
+                    node.id, node.fn.name, node.state.value, NodeState.Success.value,
+                )
+                return
+        
             self._global_seqno += 1
             node.outputs = outputs
             node.state = NodeState.Success
@@ -426,7 +469,17 @@ class Runtime:
             node.done.set()
 
     def post_exception(self, node: Node, exception: Exception) -> None:
+        self.wait_for_children_finished(node)
+        
         with self._lock:
+            if node.state in TerminalNodeStates:
+                logger.error(
+                    "Ignoring post_exception for terminal node %s (%s); transition from %s "
+                    "to %s has no effect and is ignored.",
+                    node.id, node.fn.name, node.state.value, NodeState.Error.value,
+                )
+                return
+        
             self._global_seqno += 1
             node.exception = exception
             node.state = NodeState.Error
@@ -443,9 +496,21 @@ class Runtime:
         node: Node,
         exception: Optional[CancellationException] = None,
     ) -> None:
-        """`exception` can be provided to explain the reason for cancellation
-        otherwise the Node is assigned a no-reason CancellationException."""
+        """
+        `exception` can be provided to explain the reason for cancellation
+        otherwise the Node is assigned a no-reason CancellationException.
+        """
+        self.wait_for_children_finished(node)
+
         with self._lock:
+            if node.state in TerminalNodeStates:
+                logger.error(
+                    "Ignoring post_cancel for terminal node %s (%s); transition from %s "
+                    "to %s has no effect and is ignored.",
+                    node.id, node.fn.name, node.state.value, NodeState.Canceled.value,
+                )
+                return
+        
             self._global_seqno += 1
             node.exception = exception or CancellationException()
             node.state = NodeState.Canceled

--- a/tests/test_runcontext.py
+++ b/tests/test_runcontext.py
@@ -69,6 +69,59 @@ class TestSessionBag(unittest.TestCase):
         for obj in results:
             self.assertIs(obj, results[0])
 
+    def test_session_bag_close_dedups_closers_and_continues_after_failure(self) -> None:
+        bag = SessionBag()
+
+        class CloseTracker:
+            def __init__(self, *, fail: bool = False) -> None:
+                self.fail = fail
+                self.close_calls = 0
+
+            def close(self) -> None:
+                self.close_calls += 1
+                if self.fail:
+                    raise RuntimeError("close failed")
+
+        shared = CloseTracker()
+        failing = CloseTracker(fail=True)
+        trailing = CloseTracker()
+
+        bag.get_or_put("ns-a", "shared-a", lambda: shared)
+        bag.get_or_put("ns-b", "shared-b", lambda: shared)
+        bag.get_or_put("ns-a", "failing", lambda: failing)
+        bag.get_or_put("ns-b", "trailing", lambda: trailing)
+
+        bag.close()
+
+        self.assertTrue(bag._closed)
+        self.assertEqual(bag._values, {})
+        self.assertEqual(shared.close_calls, 1)
+        self.assertEqual(failing.close_calls, 1)
+        self.assertEqual(trailing.close_calls, 1)
+
+        bag.close()
+
+        self.assertEqual(shared.close_calls, 1)
+        self.assertEqual(failing.close_calls, 1)
+        self.assertEqual(trailing.close_calls, 1)
+
+    def test_session_bag_get_or_put_rejects_new_entries_after_close(self) -> None:
+        bag = SessionBag()
+        factory_calls = 0
+
+        bag.get_or_put("ns", "existing", lambda: object())
+        bag.close()
+
+        def factory() -> object:
+            nonlocal factory_calls
+            factory_calls += 1
+            return object()
+
+        with self.assertRaisesRegex(RuntimeError, "terminally closed"):
+            bag.get_or_put("ns", "new", factory)
+
+        self.assertEqual(factory_calls, 0)
+
 
 class TestRunContextSessionBags(unittest.TestCase):
     def _build_runtime(self, root_fn: CodeFunction) -> Runtime:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,6 +1,8 @@
 import gc
 import logging
+import os
 import queue
+import sys
 import tempfile
 import threading
 import time
@@ -410,63 +412,6 @@ class TestRuntimeInvocation(unittest.TestCase):
         self.assertTrue(closed.wait(timeout=1))
         self.assertTrue(node.session_bag._closed)
 
-    def test_terminal_agent_cleans_up_client(self) -> None:
-        agent_fn = _make_agent_function("agent_cleanup")
-
-        class DummyClient:
-            def __init__(self) -> None:
-                self.closed = False
-
-            def close(self) -> None:
-                self.closed = True
-
-        class FakeAgentNode(AgentNode):
-            last_client: Optional[DummyClient] = None
-
-            def __init__(
-                self,
-                ctx: RunContext,
-                id: int,
-                fn: Function,
-                inputs: dict[str, Any],
-                parent: Optional[Node],
-                cancel_event=None,
-                client_factory=None,
-                tool_use_id=None,
-            ) -> None:
-                super().__init__(ctx, id, fn, inputs, parent, cancel_event, client_factory, tool_use_id)
-                self.client = DummyClient()
-                type(self).last_client = self.client
-
-            def run(self) -> None:
-                self.ctx.post_success("agent-output")
-
-            def on_terminal_cleanup(self) -> None:
-                self.client.close()
-                self.client = None
-                super().on_terminal_cleanup()
-
-            @property
-            def token_usage(self) -> TokenUsage:
-                return TokenUsage()
-
-            @property
-            def provider(self) -> Provider:
-                return Provider.Anthropic
-
-        with patch("netflux.runtime.get_AgentNode_impl", return_value=FakeAgentNode):
-            runtime = Runtime([agent_fn], client_factories={Provider.Anthropic: lambda: object()})
-            node = runtime.invoke(None, agent_fn, {})
-            self.assertEqual(node.result(), "agent-output")
-            assert node.thread is not None
-            node.thread.join(timeout=1)
-
-        self.assertIsNotNone(FakeAgentNode.last_client)
-        assert FakeAgentNode.last_client is not None
-        self.assertTrue(FakeAgentNode.last_client.closed)
-        assert isinstance(node, FakeAgentNode)
-        self.assertIsNone(node.client)
-
     def test_terminal_node_cleans_up_self_bag_across_terminal_outcomes(self) -> None:
         for outcome in ("success", "error", "cancel"):
             with self.subTest(outcome=outcome):
@@ -525,6 +470,26 @@ class TestRuntimeInvocation(unittest.TestCase):
         agent_fn = _make_agent_function("agent_bash_cleanup", uses=[bash_fn])
         captured: dict[str, Any] = {}
 
+        def linux_proc_identity(pid: int) -> Optional[tuple[str, str]]:
+            stat_path = Path(f"/proc/{pid}/stat")
+            try:
+                stat = stat_path.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                return None
+
+            stat_tail_idx = stat.rfind(")")
+            self.assertNotEqual(stat_tail_idx, -1, f"unexpected /proc/{pid}/stat format: {stat!r}")
+
+            fields = stat[stat_tail_idx + 2:].split()
+            self.assertGreaterEqual(
+                len(fields),
+                20,
+                f"unexpected /proc/{pid}/stat field count: {len(fields)}",
+            )
+            state = fields[0]
+            start_time = fields[19]
+            return state, start_time
+
         class FakeAgentNode(AgentNode):
             @property
             def token_usage(self) -> TokenUsage:
@@ -542,7 +507,13 @@ class TestRuntimeInvocation(unittest.TestCase):
                 )
                 result = child.result()
                 session = self.session_bag._values["bash.session"][bash_fn._bag_key(7)]
+                proc = session._proc
+                assert proc is not None
                 captured["session"] = session
+                captured["proc"] = proc
+                captured["pid"] = proc.pid
+                if sys.platform.startswith("linux") and Path("/proc").is_dir():
+                    captured["linux_proc_identity_before_cleanup"] = linux_proc_identity(proc.pid)
                 captured["parent_bag_populated_before_cleanup"] = bool(self.session_bag._values)
                 captured["child_bag_empty"] = child.session_bag._values == {}
                 self.ctx.post_success(result)
@@ -555,16 +526,35 @@ class TestRuntimeInvocation(unittest.TestCase):
             node.thread.join(timeout=2)
 
         session = captured["session"]
+        proc = captured["proc"]
+        pid = captured["pid"]
         self.assertIsInstance(session, BashSession)
         self.assertTrue(captured["parent_bag_populated_before_cleanup"])
         self.assertTrue(captured["child_bag_empty"])
         self.assertFalse(session.alive())
+        self.assertIsNotNone(proc.returncode)
         self.assertIsNone(session._proc)
         self.assertIsNone(session._stdout_thread)
         self.assertFalse(session.requires_restart)
         self.assertFalse(session._alive_once_started)
         self.assertTrue(node.session_bag._closed)
         self.assertEqual(node.session_bag._values, {})
+
+        if os.name == "posix":
+            with self.assertRaises(ChildProcessError):
+                os.waitpid(pid, os.WNOHANG)
+
+        if sys.platform.startswith("linux") and Path("/proc").is_dir():
+            before = captured["linux_proc_identity_before_cleanup"]
+            self.assertIsNotNone(before)
+            after = linux_proc_identity(pid)
+            if after is not None:
+                self.assertNotEqual(
+                    after[1],
+                    before[1],
+                    f"/proc/{pid}/stat still identifies the original bash process after cleanup "
+                    f"(state={after[0]!r})",
+                )
 
     def test_terminal_root_clears_top_level_text_editor_lock_created_by_descendant(self) -> None:
         editor_fn = TextEditor()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -28,6 +28,7 @@ from ..core import (
     SessionScope,
     TokenBill,
     TokenUsage,
+    ModelTextPart,
     CancellationException,
 )
 from ..func_lib.bash_func import Bash, BashSession
@@ -367,6 +368,88 @@ class TestRuntimeInvocation(unittest.TestCase):
         child_node = node.children[0]
         self.assertIs(child_node.ctx.cancel_event, override_event)
 
+    def test_invoke_returns_root_in_error_state_when_thread_start_fails(self) -> None:
+        fn = _make_code_function("root_start_failure")
+        runtime = Runtime([fn], client_factories={})
+        orig_start = Node.start
+
+        def fail_start(node: Node) -> None:
+            if node.fn.name != "root_start_failure":
+                orig_start(node)
+                return
+            if node.thread is not None:
+                return
+            node.thread = threading.Thread(
+                target=node.run_wrapper,
+                name=f"netflux-node-{node.id}",
+                daemon=True,
+            )
+            raise RuntimeError("can't start new thread")
+
+        with patch("netflux.core.Node.start", new=fail_start), self.assertLogs(
+            "netflux.runtime", level=logging.ERROR
+        ):
+            node = runtime.invoke(None, fn, {})
+
+        self.assertEqual(node.state, NodeState.Error)
+        self.assertTrue(node.done.is_set())
+        self.assertIsNone(node.thread)
+        self.assertIsInstance(node.exception, RuntimeError)
+        with self.assertRaisesRegex(RuntimeError, "can't start new thread"):
+            node.result()
+
+        view = runtime.get_view(node.id)
+        self.assertEqual(view.state, NodeState.Error)
+        self.assertIsInstance(view.exception, RuntimeError)
+
+    def test_invoke_returns_child_in_error_state_when_thread_start_fails(self) -> None:
+        child_fn = _make_code_function("child_start_failure")
+        captured_child: dict[str, Node] = {}
+
+        def parent_callable(ctx: RunContext) -> str:
+            child = ctx.invoke(child_fn, {})
+            captured_child["node"] = child
+            return "parent"
+
+        parent_fn = _make_code_function("parent", callable=parent_callable, uses=[child_fn])
+        runtime = Runtime([parent_fn], client_factories={})
+        orig_start = Node.start
+
+        def fail_start(node: Node) -> None:
+            if node.fn.name != "child_start_failure":
+                orig_start(node)
+                return
+            if node.thread is not None:
+                return
+            node.thread = threading.Thread(
+                target=node.run_wrapper,
+                name=f"netflux-node-{node.id}",
+                daemon=True,
+            )
+            raise RuntimeError("can't start new thread")
+
+        with patch("netflux.core.Node.start", new=fail_start), self.assertLogs(
+            "netflux.runtime", level=logging.ERROR
+        ):
+            parent_node = runtime.invoke(None, parent_fn, {})
+            self.assertEqual(parent_node.result(), "parent")
+
+        self.assertEqual(len(parent_node.children), 1)
+        child_node = parent_node.children[0]
+        self.assertIs(child_node, captured_child["node"])
+        self.assertEqual(parent_node.state, NodeState.Success)
+        self.assertTrue(parent_node.done.is_set())
+        self.assertEqual(child_node.state, NodeState.Error)
+        self.assertTrue(child_node.done.is_set())
+        self.assertIsNone(child_node.thread)
+        self.assertIsInstance(child_node.exception, RuntimeError)
+        with self.assertRaisesRegex(RuntimeError, "can't start new thread"):
+            child_node.result()
+
+        child_view = runtime.get_view(child_node.id)
+        self.assertEqual(child_view.state, NodeState.Error)
+        self.assertIsInstance(child_view.exception, RuntimeError)
+
     def test_cancel_event_triggers_cancellation(self) -> None:
         cancel_event = mp.Event()
         started = threading.Event()
@@ -410,6 +493,29 @@ class TestRuntimeInvocation(unittest.TestCase):
         assert node.thread is not None
         node.thread.join(timeout=1)
         self.assertTrue(closed.wait(timeout=1))
+        self.assertTrue(node.session_bag._closed)
+
+    def test_result_waits_for_terminal_cleanup_to_finish(self) -> None:
+        close_started = threading.Event()
+        closed = threading.Event()
+
+        class Closeable:
+            def close(self) -> None:
+                close_started.set()
+                time.sleep(0.1)
+                closed.set()
+
+        def callable(ctx: RunContext) -> str:
+            ctx.get_or_put(SessionScope.Self, "cleanup.wait", "resource", Closeable)
+            return "done"
+
+        fn = _make_code_function("cleanup_waits", callable=callable)
+        runtime = Runtime([fn], client_factories={})
+        node = runtime.invoke(None, fn, {})
+
+        self.assertEqual(node.result(), "done")
+        self.assertTrue(close_started.is_set())
+        self.assertTrue(closed.is_set())
         self.assertTrue(node.session_bag._closed)
 
     def test_terminal_node_cleans_up_self_bag_across_terminal_outcomes(self) -> None:
@@ -952,6 +1058,42 @@ class TestRuntimeInvocation(unittest.TestCase):
         self.assertIsNone(node.exception)
         self.assertTrue(
             any("post_exception" in msg and "has no effect and is ignored" in msg for msg in captured.output)
+        )
+
+    def test_agent_node_ignores_post_terminal_transcript_update(self) -> None:
+        agent_fn = _make_agent_function("agent_transcript_immutability")
+
+        class FakeAgentNode(AgentNode):
+            def run(self) -> None:
+                self.ctx.post_success("early")
+                self.transcript.append(ModelTextPart(text="late"))
+                self.ctx.post_transcript_update()
+
+            @property
+            def token_usage(self) -> TokenUsage:
+                return TokenUsage()
+
+            @property
+            def provider(self) -> Provider:
+                return Provider.Anthropic
+
+        with patch("netflux.runtime.get_AgentNode_impl", return_value=FakeAgentNode):
+            runtime = Runtime([agent_fn], client_factories={Provider.Anthropic: lambda: object()})
+            with self.assertLogs("netflux.runtime", level=logging.ERROR) as captured:
+                node = runtime.invoke(None, agent_fn, {})
+                self.assertEqual(node.result(), "early")
+
+            assert node.thread is not None
+            node.thread.join(timeout=1)
+
+        view = runtime.get_view(node.id)
+        self.assertEqual(view.state, NodeState.Success)
+        self.assertEqual(view.transcript, ())
+        self.assertTrue(
+            any(
+                "post_transcript_update" in msg and "has no effect and is ignored" in msg
+                for msg in captured.output
+            )
         )
 
     def test_code_node_preserves_explicit_terminal_outcome(self) -> None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,8 +1,12 @@
+import gc
 import logging
 import queue
+import tempfile
 import threading
 import time
 import unittest
+import weakref
+from pathlib import Path
 from typing import Any, Iterable, List, Optional, Union
 from unittest.mock import patch
 import multiprocessing as mp
@@ -24,6 +28,8 @@ from ..core import (
     TokenUsage,
     CancellationException,
 )
+from ..func_lib.bash_func import Bash, BashSession
+from ..func_lib.text_editor_func import TextEditor
 from ..providers import Provider
 
 
@@ -109,7 +115,7 @@ def _register_dummy_node(runtime: Runtime, node: Node) -> None:
         runtime._global_seqno += 1
         # Create NodeObservable with initial view
         runtime._node_observables[node.id] = NodeObservable(
-            cond=mp.Condition(runtime._lock),
+            cond=threading.Condition(runtime._lock),
             touch_seqno=runtime._global_seqno,
             view=runtime._build_node_view(node),
         )
@@ -383,6 +389,749 @@ class TestRuntimeInvocation(unittest.TestCase):
         self.assertIsNotNone(node.exception)
         self.assertIsInstance(node.exception, CancellationException)
 
+    def test_terminal_node_closes_its_session_bag_values(self) -> None:
+        closed = threading.Event()
+
+        class Closeable:
+            def close(self) -> None:
+                closed.set()
+
+        def callable(ctx: RunContext) -> str:
+            ctx.get_or_put(SessionScope.Self, "ns", "key", Closeable)
+            return "done"
+
+        fn = _make_code_function("cleanup", callable=callable)
+        runtime = Runtime([fn], client_factories={})
+        node = runtime.invoke(None, fn, {})
+
+        self.assertEqual(node.result(), "done")
+        assert node.thread is not None
+        node.thread.join(timeout=1)
+        self.assertTrue(closed.wait(timeout=1))
+        self.assertTrue(node.session_bag._closed)
+
+    def test_terminal_agent_cleans_up_client(self) -> None:
+        agent_fn = _make_agent_function("agent_cleanup")
+
+        class DummyClient:
+            def __init__(self) -> None:
+                self.closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
+        class FakeAgentNode(AgentNode):
+            last_client: Optional[DummyClient] = None
+
+            def __init__(
+                self,
+                ctx: RunContext,
+                id: int,
+                fn: Function,
+                inputs: dict[str, Any],
+                parent: Optional[Node],
+                cancel_event=None,
+                client_factory=None,
+                tool_use_id=None,
+            ) -> None:
+                super().__init__(ctx, id, fn, inputs, parent, cancel_event, client_factory, tool_use_id)
+                self.client = DummyClient()
+                type(self).last_client = self.client
+
+            def run(self) -> None:
+                self.ctx.post_success("agent-output")
+
+            def on_terminal_cleanup(self) -> None:
+                self.client.close()
+                self.client = None
+                super().on_terminal_cleanup()
+
+            @property
+            def token_usage(self) -> TokenUsage:
+                return TokenUsage()
+
+            @property
+            def provider(self) -> Provider:
+                return Provider.Anthropic
+
+        with patch("netflux.runtime.get_AgentNode_impl", return_value=FakeAgentNode):
+            runtime = Runtime([agent_fn], client_factories={Provider.Anthropic: lambda: object()})
+            node = runtime.invoke(None, agent_fn, {})
+            self.assertEqual(node.result(), "agent-output")
+            assert node.thread is not None
+            node.thread.join(timeout=1)
+
+        self.assertIsNotNone(FakeAgentNode.last_client)
+        assert FakeAgentNode.last_client is not None
+        self.assertTrue(FakeAgentNode.last_client.closed)
+        assert isinstance(node, FakeAgentNode)
+        self.assertIsNone(node.client)
+
+    def test_terminal_node_cleans_up_self_bag_across_terminal_outcomes(self) -> None:
+        for outcome in ("success", "error", "cancel"):
+            with self.subTest(outcome=outcome):
+                closed = threading.Event()
+                started = threading.Event()
+
+                class Closeable:
+                    def __init__(self) -> None:
+                        self.close_calls = 0
+
+                    def close(self) -> None:
+                        self.close_calls += 1
+                        closed.set()
+
+                resource = Closeable()
+                cancel_event = threading.Event() if outcome == "cancel" else None
+
+                def callable(ctx: RunContext) -> str:
+                    ctx.get_or_put(SessionScope.Self, "cleanup.self", "resource", lambda: resource)
+                    started.set()
+                    if outcome == "success":
+                        return "done"
+                    if outcome == "error":
+                        raise RuntimeError("boom")
+                    while not ctx.cancel_requested():
+                        time.sleep(0.01)
+                    raise CancellationException("stop")
+
+                fn = _make_code_function(f"cleanup_{outcome}", callable=callable)
+                runtime = Runtime([fn], client_factories={})
+                node = runtime.invoke(None, fn, {}, cancel_event=cancel_event)
+
+                if outcome == "success":
+                    self.assertEqual(node.result(), "done")
+                elif outcome == "error":
+                    with self.assertRaisesRegex(RuntimeError, "boom"):
+                        node.result()
+                else:
+                    self.assertTrue(started.wait(timeout=1))
+                    assert cancel_event is not None
+                    cancel_event.set()
+                    with self.assertRaises(CancellationException):
+                        node.result()
+
+                assert node.thread is not None
+                node.thread.join(timeout=1)
+                self.assertTrue(closed.wait(timeout=1))
+                self.assertEqual(resource.close_calls, 1)
+                self.assertTrue(node.session_bag._closed)
+                self.assertEqual(node.session_bag._values, {})
+                with self.assertRaisesRegex(RuntimeError, "terminally closed"):
+                    node.session_bag.get_or_put("cleanup.self", "late", lambda: object())
+
+    def test_terminal_agent_closes_parent_scoped_bash_session(self) -> None:
+        bash_fn = Bash()
+        agent_fn = _make_agent_function("agent_bash_cleanup", uses=[bash_fn])
+        captured: dict[str, Any] = {}
+
+        class FakeAgentNode(AgentNode):
+            @property
+            def token_usage(self) -> TokenUsage:
+                return TokenUsage()
+
+            @property
+            def provider(self) -> Provider:
+                return Provider.Anthropic
+
+            def run(self) -> None:
+                child = self.ctx.invoke(
+                    bash_fn,
+                    {"command": "echo hello from bash", "session_id": 7},
+                    tool_use_id="tool-1",
+                )
+                result = child.result()
+                session = self.session_bag._values["bash.session"][bash_fn._bag_key(7)]
+                captured["session"] = session
+                captured["parent_bag_populated_before_cleanup"] = bool(self.session_bag._values)
+                captured["child_bag_empty"] = child.session_bag._values == {}
+                self.ctx.post_success(result)
+
+        with patch("netflux.runtime.get_AgentNode_impl", return_value=FakeAgentNode):
+            runtime = Runtime([agent_fn], client_factories={Provider.Anthropic: lambda: object()})
+            node = runtime.invoke(None, agent_fn, {})
+            self.assertEqual(node.result().strip(), "hello from bash")
+            assert node.thread is not None
+            node.thread.join(timeout=2)
+
+        session = captured["session"]
+        self.assertIsInstance(session, BashSession)
+        self.assertTrue(captured["parent_bag_populated_before_cleanup"])
+        self.assertTrue(captured["child_bag_empty"])
+        self.assertFalse(session.alive())
+        self.assertIsNone(session._proc)
+        self.assertIsNone(session._stdout_thread)
+        self.assertFalse(session.requires_restart)
+        self.assertFalse(session._alive_once_started)
+        self.assertTrue(node.session_bag._closed)
+        self.assertEqual(node.session_bag._values, {})
+
+    def test_terminal_root_clears_top_level_text_editor_lock_created_by_descendant(self) -> None:
+        editor_fn = TextEditor()
+        captured: dict[str, Any] = {}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "notes.txt"
+            target.write_text("before\n", encoding="utf-8")
+
+            def grandchild_callable(ctx: RunContext) -> str:
+                editor_node = ctx.invoke(
+                    editor_fn,
+                    {
+                        "command": "str_replace",
+                        "path": str(target),
+                        "old_str": "before\n",
+                        "new_str": "after\n",
+                    },
+                )
+                result = editor_node.result()
+                top_bag = ctx.object_bags[SessionScope.TopLevel]
+                lock_key = editor_fn._file_lock_key(target.resolve())
+                lock = top_bag._values[editor_fn._FILE_LOCK_NAMESPACE][lock_key]
+                captured["top_level_bag_id"] = id(top_bag)
+                captured["lock_ref"] = weakref.ref(lock)
+                captured["lock_keys_before_cleanup"] = tuple(
+                    top_bag._values[editor_fn._FILE_LOCK_NAMESPACE].keys()
+                )
+                return result
+
+            grandchild_fn = _make_code_function(
+                "grandchild_editor_cleanup",
+                callable=grandchild_callable,
+                uses=[editor_fn],
+            )
+
+            def child_callable(ctx: RunContext) -> str:
+                return ctx.invoke(grandchild_fn, {}).result()
+
+            child_fn = _make_code_function(
+                "child_editor_cleanup",
+                callable=child_callable,
+                uses=[grandchild_fn],
+            )
+
+            def root_callable(ctx: RunContext) -> str:
+                return ctx.invoke(child_fn, {}).result()
+
+            root_fn = _make_code_function(
+                "root_editor_cleanup",
+                callable=root_callable,
+                uses=[child_fn],
+            )
+
+            runtime = Runtime([root_fn], client_factories={})
+            root_node = runtime.invoke(None, root_fn, {})
+            self.assertEqual(root_node.result(), "Replace successful.")
+            assert root_node.thread is not None
+            root_node.thread.join(timeout=1)
+
+            self.assertEqual(target.read_text(encoding="utf-8"), "after\n")
+            self.assertEqual(captured["top_level_bag_id"], id(root_node.session_bag))
+            self.assertTrue(captured["lock_keys_before_cleanup"])
+            self.assertTrue(root_node.session_bag._closed)
+            self.assertEqual(root_node.session_bag._values, {})
+
+            gc.collect()
+            self.assertIsNone(captured["lock_ref"]())
+
+    def test_descendant_can_use_ancestor_session_bags_while_ancestor_terminalization_is_deferred(self) -> None:
+        root_returning = threading.Event()
+        child_returning = threading.Event()
+        grandchild_started = threading.Event()
+        allow_grandchild_finish = threading.Event()
+        observed: dict[str, Any] = {}
+
+        def grandchild_callable(ctx: RunContext) -> str:
+            grandchild_started.set()
+            self.assertTrue(root_returning.wait(timeout=1))
+            self.assertTrue(child_returning.wait(timeout=1))
+
+            assert ctx.node is not None
+            assert ctx.node.parent is not None
+            root_node = ctx.node.parent.parent
+            child_node = ctx.node.parent
+            assert root_node is not None
+
+            deadline = time.monotonic() + 1
+            while time.monotonic() < deadline:
+                if (
+                    root_node.state is NodeState.Running
+                    and child_node.state is NodeState.Running
+                    and not root_node.done.is_set()
+                    and not child_node.done.is_set()
+                ):
+                    break
+                time.sleep(0.01)
+            else:
+                self.fail("Ancestors did not remain Running while terminalization was deferred")
+
+            top_bag = ctx.object_bags[SessionScope.TopLevel]
+            parent_bag = ctx.object_bags[SessionScope.Parent]
+            observed["root_bag_closed_before_access"] = top_bag._closed
+            observed["child_bag_closed_before_access"] = parent_bag._closed
+            observed["root_value"] = ctx.get_or_put(
+                SessionScope.TopLevel,
+                "deferred.cleanup",
+                "root",
+                lambda: "wrong-root",
+            )
+            observed["child_value"] = ctx.get_or_put(
+                SessionScope.Parent,
+                "deferred.cleanup",
+                "child",
+                lambda: "wrong-child",
+            )
+
+            self.assertTrue(allow_grandchild_finish.wait(timeout=5))
+            return "grandchild-done"
+
+        grandchild_fn = _make_code_function(
+            "grandchild_deferred_bag",
+            callable=grandchild_callable,
+        )
+
+        def child_callable(ctx: RunContext) -> str:
+            ctx.get_or_put(
+                SessionScope.Self,
+                "deferred.cleanup",
+                "child",
+                lambda: "child-value",
+            )
+            ctx.invoke(grandchild_fn, {})
+            child_returning.set()
+            return "child-done"
+
+        child_fn = _make_code_function(
+            "child_deferred_bag",
+            callable=child_callable,
+            uses=[grandchild_fn],
+        )
+
+        def root_callable(ctx: RunContext) -> str:
+            ctx.get_or_put(
+                SessionScope.Self,
+                "deferred.cleanup",
+                "root",
+                lambda: "root-value",
+            )
+            ctx.invoke(child_fn, {})
+            root_returning.set()
+            return "root-done"
+
+        root_fn = _make_code_function(
+            "root_deferred_bag",
+            callable=root_callable,
+            uses=[child_fn],
+        )
+
+        runtime = Runtime([root_fn], client_factories={})
+        root_node = runtime.invoke(None, root_fn, {})
+
+        self.assertTrue(grandchild_started.wait(timeout=1))
+        self.assertTrue(root_returning.wait(timeout=1))
+        self.assertTrue(child_returning.wait(timeout=1))
+
+        self.assertEqual(root_node.state, NodeState.Running)
+        self.assertFalse(root_node.done.is_set())
+        child_node = root_node.children[0]
+        grandchild_node = child_node.children[0]
+        self.assertEqual(child_node.state, NodeState.Running)
+        self.assertFalse(child_node.done.is_set())
+
+        allow_grandchild_finish.set()
+
+        self.assertEqual(root_node.result(), "root-done")
+        self.assertEqual(child_node.result(), "child-done")
+        self.assertEqual(grandchild_node.result(), "grandchild-done")
+
+        assert root_node.thread is not None
+        assert child_node.thread is not None
+        assert grandchild_node.thread is not None
+        root_node.thread.join(timeout=1)
+        child_node.thread.join(timeout=1)
+        grandchild_node.thread.join(timeout=1)
+
+        self.assertFalse(observed["root_bag_closed_before_access"])
+        self.assertFalse(observed["child_bag_closed_before_access"])
+        self.assertEqual(observed["root_value"], "root-value")
+        self.assertEqual(observed["child_value"], "child-value")
+        self.assertTrue(root_node.session_bag._closed)
+        self.assertTrue(child_node.session_bag._closed)
+        self.assertTrue(grandchild_node.session_bag._closed)
+
+    def test_terminal_root_implies_descendant_subtree_is_terminal(self) -> None:
+        root_returning = threading.Event()
+        child_returning = threading.Event()
+        grandchild_started = threading.Event()
+        allow_grandchild_finish = threading.Event()
+
+        def grandchild_callable(ctx: RunContext) -> str:
+            grandchild_started.set()
+            self.assertTrue(allow_grandchild_finish.wait(timeout=5))
+            return "grandchild-done"
+
+        grandchild_fn = _make_code_function(
+            "grandchild_subtree_terminal",
+            callable=grandchild_callable,
+        )
+
+        def child_callable(ctx: RunContext) -> str:
+            ctx.invoke(grandchild_fn, {})
+            child_returning.set()
+            return "child-done"
+
+        child_fn = _make_code_function(
+            "child_subtree_terminal",
+            callable=child_callable,
+            uses=[grandchild_fn],
+        )
+
+        def root_callable(ctx: RunContext) -> str:
+            ctx.invoke(child_fn, {})
+            root_returning.set()
+            return "root-done"
+
+        root_fn = _make_code_function(
+            "root_subtree_terminal",
+            callable=root_callable,
+            uses=[child_fn],
+        )
+
+        runtime = Runtime([root_fn], client_factories={})
+        root_node = runtime.invoke(None, root_fn, {})
+
+        self.assertTrue(grandchild_started.wait(timeout=1))
+        self.assertTrue(root_returning.wait(timeout=1))
+        self.assertTrue(child_returning.wait(timeout=1))
+
+        child_node = root_node.children[0]
+        grandchild_node = child_node.children[0]
+
+        self.assertEqual(root_node.state, NodeState.Running)
+        self.assertEqual(child_node.state, NodeState.Running)
+        self.assertEqual(grandchild_node.state, NodeState.Running)
+        self.assertFalse(root_node.done.is_set())
+        self.assertFalse(child_node.done.is_set())
+        self.assertFalse(grandchild_node.done.is_set())
+
+        allow_grandchild_finish.set()
+
+        self.assertEqual(root_node.result(), "root-done")
+        self.assertEqual(child_node.result(), "child-done")
+        self.assertEqual(grandchild_node.result(), "grandchild-done")
+        self.assertEqual(root_node.state, NodeState.Success)
+        self.assertEqual(child_node.state, NodeState.Success)
+        self.assertEqual(grandchild_node.state, NodeState.Success)
+        self.assertTrue(root_node.done.is_set())
+        self.assertTrue(child_node.done.is_set())
+        self.assertTrue(grandchild_node.done.is_set())
+
+    def test_watch_keeps_node_running_while_terminalization_is_blocked_on_child(self) -> None:
+        child_started = threading.Event()
+        root_returning = threading.Event()
+        child_release = threading.Event()
+
+        child_fn = _make_code_function(
+            "child_watch_running",
+            callable=_make_code_callable(
+                "child-done",
+                start_event=child_started,
+                proceed_event=child_release,
+            ),
+        )
+
+        def root_callable(ctx: RunContext) -> str:
+            ctx.invoke(child_fn, {})
+            root_returning.set()
+            return "root-done"
+
+        root_fn = _make_code_function(
+            "root_watch_running",
+            callable=root_callable,
+            uses=[child_fn],
+        )
+
+        runtime = Runtime([root_fn], client_factories={})
+        root_node = runtime.invoke(None, root_fn, {})
+
+        self.assertTrue(child_started.wait(timeout=1))
+        self.assertTrue(root_returning.wait(timeout=1))
+        time.sleep(0.05)
+
+        running_view = runtime.get_view(root_node.id)
+        self.assertEqual(running_view.state, NodeState.Running)
+        self.assertFalse(root_node.done.is_set())
+        self.assertIsNone(root_node.watch(as_of_seq=running_view.update_seqnum, timeout=0.05))
+        self.assertEqual(runtime.get_view(root_node.id).state, NodeState.Running)
+
+        child_release.set()
+        self.assertEqual(root_node.result(), "root-done")
+        self.assertEqual(runtime.get_view(root_node.id).state, NodeState.Success)
+
+    def test_terminalization_waits_for_direct_children_across_terminal_outcomes(self) -> None:
+        for outcome, expected_state in (
+            ("success", NodeState.Success),
+            ("error", NodeState.Error),
+            ("cancel", NodeState.Canceled),
+        ):
+            with self.subTest(outcome=outcome):
+                child_started = threading.Event()
+                child_release = threading.Event()
+                cancel_event = threading.Event() if outcome == "cancel" else None
+
+                child_fn = _make_code_function(
+                    f"child_wait_{outcome}",
+                    callable=_make_code_callable(
+                        "child-done",
+                        start_event=child_started,
+                        proceed_event=child_release,
+                    ),
+                )
+
+                def parent_callable(ctx: RunContext) -> str:
+                    ctx.invoke(child_fn, {})
+                    if outcome == "success":
+                        return "parent-done"
+                    if outcome == "error":
+                        raise RuntimeError("parent boom")
+                    while not ctx.cancel_requested():
+                        time.sleep(0.01)
+                    raise CancellationException("parent cancel")
+
+                parent_fn = _make_code_function(
+                    f"parent_wait_{outcome}",
+                    callable=parent_callable,
+                    uses=[child_fn],
+                )
+
+                runtime = Runtime([parent_fn], client_factories={})
+                parent_node = runtime.invoke(None, parent_fn, {}, cancel_event=cancel_event)
+
+                self.assertTrue(child_started.wait(timeout=1))
+                if cancel_event is not None:
+                    cancel_event.set()
+                time.sleep(0.05)
+
+                self.assertEqual(parent_node.state, NodeState.Running)
+                self.assertFalse(parent_node.done.is_set())
+                self.assertEqual(len(parent_node.children), 1)
+                child_node = parent_node.children[0]
+                self.assertFalse(child_node.done.is_set())
+
+                child_release.set()
+
+                if outcome == "success":
+                    self.assertEqual(parent_node.result(), "parent-done")
+                elif outcome == "error":
+                    with self.assertRaisesRegex(RuntimeError, "parent boom"):
+                        parent_node.result()
+                else:
+                    with self.assertRaises(CancellationException):
+                        parent_node.result()
+
+                self.assertEqual(parent_node.state, expected_state)
+                self.assertTrue(parent_node.done.is_set())
+                self.assertTrue(child_node.done.is_set())
+
+    def test_agent_node_preserves_explicit_terminal_outcome_against_wrapper_exception(self) -> None:
+        agent_fn = _make_agent_function("agent_terminal_immutability")
+
+        class FakeAgentNode(AgentNode):
+            def run(self) -> None:
+                self.ctx.post_success("early")
+                raise RuntimeError("late boom")
+
+            @property
+            def token_usage(self) -> TokenUsage:
+                return TokenUsage()
+
+            @property
+            def provider(self) -> Provider:
+                return Provider.Anthropic
+
+        with patch("netflux.runtime.get_AgentNode_impl", return_value=FakeAgentNode):
+            runtime = Runtime([agent_fn], client_factories={Provider.Anthropic: lambda: object()})
+            with self.assertLogs("netflux.runtime", level=logging.ERROR) as captured:
+                node = runtime.invoke(None, agent_fn, {})
+                self.assertEqual(node.result(), "early")
+
+            assert node.thread is not None
+            node.thread.join(timeout=1)
+
+        self.assertEqual(node.state, NodeState.Success)
+        self.assertIsNone(node.exception)
+        self.assertTrue(
+            any("post_exception" in msg and "has no effect and is ignored" in msg for msg in captured.output)
+        )
+
+    def test_code_node_preserves_explicit_terminal_outcome(self) -> None:
+        cases = (
+            (
+                "success_then_return",
+                lambda ctx: (ctx.post_success("early"), "late")[1],
+                NodeState.Success,
+                "early",
+                None,
+            ),
+            (
+                "exception_then_return",
+                lambda ctx: (ctx.post_exception(RuntimeError("early boom")), "late")[1],
+                NodeState.Error,
+                None,
+                RuntimeError,
+            ),
+            (
+                "cancel_then_return",
+                lambda ctx: (
+                    ctx.post_cancel(CancellationException("early cancel")),
+                    "late",
+                )[1],
+                NodeState.Canceled,
+                None,
+                CancellationException,
+            ),
+            (
+                "success_then_raise",
+                lambda ctx: (_ for _ in ()).throw(RuntimeError("late boom")),
+                NodeState.Success,
+                "early",
+                None,
+            ),
+        )
+
+        for name, body, expected_state, expected_output, expected_exc_type in cases:
+            with self.subTest(case=name):
+                def callable(ctx: RunContext) -> Any:
+                    if name == "success_then_raise":
+                        ctx.post_success("early")
+                    return body(ctx)
+
+                fn = _make_code_function(name, callable=callable)
+                runtime = Runtime([fn], client_factories={})
+                with self.assertLogs("netflux.runtime", level=logging.ERROR) as captured:
+                    node = runtime.invoke(None, fn, {})
+
+                    if expected_exc_type is None:
+                        self.assertEqual(node.result(), expected_output)
+                    elif expected_exc_type is RuntimeError:
+                        with self.assertRaisesRegex(RuntimeError, "early boom"):
+                            node.result()
+                    else:
+                        with self.assertRaisesRegex(CancellationException, "early cancel"):
+                            node.result()
+
+                    assert node.thread is not None
+                    node.thread.join(timeout=1)
+                self.assertEqual(node.state, expected_state)
+                self.assertTrue(any("has no effect and is ignored" in msg for msg in captured.output))
+
+    def test_invoke_rejects_child_after_explicit_terminal_post_success_or_exception(self) -> None:
+        child_fn = _make_code_function("late_child")
+        cases = (
+            (
+                "success",
+                lambda ctx: ctx.post_success("early"),
+                NodeState.Success,
+                "early",
+                None,
+            ),
+            (
+                "exception",
+                lambda ctx: ctx.post_exception(RuntimeError("early boom")),
+                NodeState.Error,
+                None,
+                RuntimeError,
+            ),
+        )
+
+        for name, post_terminal, expected_state, expected_output, expected_exc_type in cases:
+            with self.subTest(case=name):
+                def parent_callable(ctx: RunContext) -> str:
+                    post_terminal(ctx)
+                    with self.assertRaisesRegex(RuntimeError, "terminal node"):
+                        ctx.invoke(child_fn, {})
+                    return "late"
+
+                parent_fn = _make_code_function(
+                    f"terminal_parent_{name}",
+                    callable=parent_callable,
+                    uses=[child_fn],
+                )
+                runtime = Runtime([parent_fn], client_factories={})
+                with self.assertLogs("netflux.runtime", level=logging.ERROR) as captured:
+                    parent_node = runtime.invoke(None, parent_fn, {})
+
+                    if expected_exc_type is None:
+                        self.assertEqual(parent_node.result(), expected_output)
+                    else:
+                        with self.assertRaisesRegex(RuntimeError, "early boom"):
+                            parent_node.result()
+
+                assert parent_node.thread is not None
+                parent_node.thread.join(timeout=1)
+                self.assertEqual(parent_node.state, expected_state)
+                self.assertEqual(parent_node.children, [])
+                self.assertTrue(any("has no effect and is ignored" in msg for msg in captured.output))
+
+    def test_invoke_rejects_terminal_agent_child_before_construction(self) -> None:
+        agent_fn = _make_agent_function("late_agent")
+        observed = {"factory_calls": 0, "agent_inits": 0}
+
+        class FakeAgentNode(AgentNode):
+            def __init__(
+                self,
+                ctx: RunContext,
+                id: int,
+                fn: Function,
+                inputs: dict[str, Any],
+                parent: Optional[Node],
+                cancel_event=None,
+                client_factory=None,
+                tool_use_id=None,
+            ) -> None:
+                observed["agent_inits"] += 1
+                super().__init__(ctx, id, fn, inputs, parent, cancel_event, client_factory, tool_use_id)
+                assert client_factory is not None
+                self.client = client_factory()
+
+            def run(self) -> None:
+                self.ctx.post_success("agent-output")
+
+            @property
+            def token_usage(self) -> TokenUsage:
+                return TokenUsage()
+
+            @property
+            def provider(self) -> Provider:
+                return Provider.Anthropic
+
+        def factory() -> object:
+            observed["factory_calls"] += 1
+            return object()
+
+        def parent_callable(ctx: RunContext) -> str:
+            ctx.post_success("early")
+            with self.assertRaisesRegex(RuntimeError, "terminal node"):
+                ctx.invoke(agent_fn, {})
+            return "late"
+
+        parent_fn = _make_code_function(
+            "terminal_parent_agent_child",
+            callable=parent_callable,
+            uses=[agent_fn],
+        )
+
+        with patch("netflux.runtime.get_AgentNode_impl", return_value=FakeAgentNode):
+            runtime = Runtime([parent_fn], client_factories={Provider.Anthropic: factory})
+            parent_node = runtime.invoke(None, parent_fn, {})
+            self.assertEqual(parent_node.result(), "early")
+
+        assert parent_node.thread is not None
+        parent_node.thread.join(timeout=1)
+        self.assertEqual(parent_node.children, [])
+        self.assertEqual(observed["agent_inits"], 0)
+        self.assertEqual(observed["factory_calls"], 0)
+
 
 class TestRuntimeObservability(unittest.TestCase):
     def test_list_toplevel_views_returns_snapshots(self) -> None:
@@ -447,7 +1196,7 @@ class TestRuntimeStateTransitions(unittest.TestCase):
         _register_dummy_node(runtime, node)
         return runtime, node
 
-    def test_post_status_update_mutates_state_and_notifies(self) -> None:
+    def test_post_running_transitions_waiting_to_running_and_notifies(self) -> None:
         runtime, node = self._make_runtime_with_dummy_node()
         initial_view = runtime.get_view(node.id)
 
@@ -466,13 +1215,40 @@ class TestRuntimeStateTransitions(unittest.TestCase):
         self.assertTrue(watcher_started.wait(timeout=1))
         self.assertTrue(results.empty())
 
-        runtime.post_status_update(node, NodeState.Running)
+        runtime.post_running(node)
         thread.join(timeout=1)
         self.assertFalse(thread.is_alive())
         updated = results.get(timeout=1)
         self.assertEqual(node.state, NodeState.Running)
         self.assertEqual(updated.state, NodeState.Running)
         self.assertGreater(updated.update_seqnum, initial_view.update_seqnum)
+
+    def test_post_running_is_noop_when_already_running(self) -> None:
+        runtime, node = self._make_runtime_with_dummy_node()
+        runtime.post_running(node)
+        initial_view = runtime.get_view(node.id)
+
+        runtime.post_running(node)
+
+        self.assertEqual(node.state, NodeState.Running)
+        self.assertEqual(runtime.get_view(node.id), initial_view)
+        self.assertIsNone(runtime.watch(node.id, as_of_seq=initial_view.update_seqnum, timeout=0.01))
+
+    def test_post_running_ignores_terminal_node(self) -> None:
+        runtime, node = self._make_runtime_with_dummy_node()
+        runtime.post_success(node, "ok")
+        initial_view = runtime.get_view(node.id)
+
+        with self.assertLogs("netflux.runtime", level=logging.ERROR) as captured:
+            runtime.post_running(node)
+
+        self.assertEqual(node.state, NodeState.Success)
+        self.assertEqual(node.outputs, "ok")
+        self.assertTrue(node.done.is_set())
+        self.assertEqual(runtime.get_view(node.id), initial_view)
+        self.assertTrue(
+            any("post_running" in msg and "no effect and is ignored" in msg for msg in captured.output)
+        )
 
     def test_post_success_sets_outputs_and_marks_done(self) -> None:
         runtime, node = self._make_runtime_with_dummy_node(node_id=2)
@@ -511,6 +1287,58 @@ class TestRuntimeStateTransitions(unittest.TestCase):
         self.assertEqual(view.state, NodeState.Canceled)
         self.assertIsNotNone(view.exception)
         self.assertIsInstance(view.exception, CancellationException)
+
+    def test_terminal_posts_ignore_later_terminal_transitions(self) -> None:
+        cases = (
+            (
+                "success_then_exception",
+                lambda runtime, node: runtime.post_success(node, "ok"),
+                lambda runtime, node: runtime.post_exception(node, RuntimeError("late boom")),
+                NodeState.Success,
+                "ok",
+                None,
+                "post_exception",
+            ),
+            (
+                "error_then_cancel",
+                lambda runtime, node: runtime.post_exception(node, RuntimeError("boom")),
+                lambda runtime, node: runtime.post_cancel(node, CancellationException("late cancel")),
+                NodeState.Error,
+                None,
+                RuntimeError,
+                "post_cancel",
+            ),
+            (
+                "canceled_then_success",
+                lambda runtime, node: runtime.post_cancel(node, CancellationException("cancel")),
+                lambda runtime, node: runtime.post_success(node, "late"),
+                NodeState.Canceled,
+                None,
+                CancellationException,
+                "post_success",
+            ),
+        )
+
+        for name, first_post, second_post, expected_state, expected_output, expected_exc_type, ignored_call in cases:
+            with self.subTest(case=name):
+                runtime, node = self._make_runtime_with_dummy_node()
+                first_post(runtime, node)
+                first_exception = node.exception
+
+                with self.assertLogs("netflux.runtime", level=logging.ERROR) as captured:
+                    second_post(runtime, node)
+
+                self.assertEqual(node.state, expected_state)
+                self.assertEqual(node.outputs, expected_output)
+                if expected_exc_type is None:
+                    self.assertIsNone(node.exception)
+                else:
+                    self.assertIs(node.exception, first_exception)
+                    self.assertIsInstance(node.exception, expected_exc_type)
+                self.assertTrue(node.done.is_set())
+                self.assertTrue(
+                    any(ignored_call in msg and "has no effect and is ignored" in msg for msg in captured.output)
+                )
 
     def test_publish_viewtree_update_refreshes_ancestors(self) -> None:
         runtime = Runtime([], client_factories={})

--- a/tests/test_text_editor.py
+++ b/tests/test_text_editor.py
@@ -440,6 +440,25 @@ class TestTextEditorCreateBehavior(unittest.TestCase):
 
 
 class TestTextEditorConcurrency(unittest.TestCase):
+    def test_get_file_lock_reuses_same_lock_for_same_top_level_bag_and_path(self) -> None:
+        editor = TextEditor()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "file.txt"
+
+            top_bag = SessionBag()
+            node_a = _DummyNode()
+            node_b = _DummyNode()
+            ctx_a = RunContext(runtime=None, node=node_a)  # type: ignore[arg-type]
+            ctx_b = RunContext(runtime=None, node=node_b)  # type: ignore[arg-type]
+            ctx_a.object_bags = {SessionScope.TopLevel: top_bag, SessionScope.Self: node_a.session_bag}
+            ctx_b.object_bags = {SessionScope.TopLevel: top_bag, SessionScope.Self: node_b.session_bag}
+
+            lock_a = editor._get_file_lock(ctx_a, target.resolve())
+            lock_b = editor._get_file_lock(ctx_b, target.resolve())
+
+            self.assertIs(lock_a, lock_b)
+
     def test_parallel_str_replace_same_file_is_serialized(self) -> None:
         editor = TextEditor()
 
@@ -457,29 +476,11 @@ class TestTextEditorConcurrency(unittest.TestCase):
             # Ensure LF line endings (Path.write_text() may translate to CRLF on Windows).
             editor.call(ctx_a, command="create", path=str(target), file_text="a=1\nb=2\n")
 
-            file_lock = editor._get_file_lock(ctx_a, target.resolve())
-            orig_acquire = file_lock.acquire
-            orig_release = file_lock.release
-
-            b_waiting_on_lock = threading.Event()
-            b_acquired_lock = threading.Event()
-
-            def patched_acquire(*args, **kwargs):
-                if threading.current_thread().name == "writer-b":
-                    if not orig_acquire(False):
-                        b_waiting_on_lock.set()
-                    else:
-                        orig_release()
-                    out = orig_acquire(*args, **kwargs)
-                    b_acquired_lock.set()
-                    return out
-                return orig_acquire(*args, **kwargs)
-
-            file_lock.acquire = patched_acquire
-
             a_prewrite = threading.Event()
             allow_a_write = threading.Event()
             a_read_started = threading.Event()
+            b_waiting_on_lock = threading.Event()
+            b_acquired_lock = threading.Event()
             b_read_started = threading.Event()
             errors: list[Exception] = []
 
@@ -488,6 +489,26 @@ class TestTextEditorConcurrency(unittest.TestCase):
 
             reads: dict[str, str] = {}
             writes: dict[str, str] = {}
+
+            class _TestFileLock:
+                def __init__(self) -> None:
+                    self._lock = threading.Lock()
+
+                def acquire(self, *args, **kwargs):
+                    if threading.current_thread().name == "writer-b":
+                        if not self._lock.acquire(False):
+                            b_waiting_on_lock.set()
+                        else:
+                            self._lock.release()
+                        out = self._lock.acquire(*args, **kwargs)
+                        b_acquired_lock.set()
+                        return out
+                    return self._lock.acquire(*args, **kwargs)
+
+                def release(self) -> None:
+                    self._lock.release()
+
+            file_lock = _TestFileLock()
 
             def patched_atomic_write(p: Path, data: str) -> None:
                 writes[threading.current_thread().name] = data
@@ -505,6 +526,11 @@ class TestTextEditorConcurrency(unittest.TestCase):
                 if threading.current_thread().name == "writer-b":
                     b_read_started.set()
                 return content
+
+            def patched_get_file_lock(ctx: RunContext, p: Path):
+                self.assertIn(ctx, (ctx_a, ctx_b))
+                self.assertEqual(target.resolve(), p)
+                return file_lock
 
             def worker_a() -> None:
                 try:
@@ -531,6 +557,7 @@ class TestTextEditorConcurrency(unittest.TestCase):
                     errors.append(exc)
 
             with (
+                patch.object(editor, "_get_file_lock", side_effect=patched_get_file_lock),
                 patch.object(editor, "_atomic_write_text", side_effect=patched_atomic_write),
                 patch.object(editor, "_read_text_preserve_eols", side_effect=patched_read_text),
             ):

--- a/tests/tui/test_tui_controllers.py
+++ b/tests/tui/test_tui_controllers.py
@@ -2354,6 +2354,10 @@ class TestTUIState(unittest.TestCase):
             provider=None,
             cancel_event=unittest.mock.ANY,
         )
+        self.assertIsInstance(
+            invoke_mock.call_args.kwargs["cancel_event"],
+            threading.Event,
+        )
 
     def test_launch_form_agent_provider_override_is_forwarded_only_for_root_invoke(self) -> None:
         fn = AgentFunction(

--- a/tui/console.py
+++ b/tui/console.py
@@ -29,7 +29,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
-from multiprocessing.synchronize import Event
+from threading import Event
 from typing import Any, Iterator, Mapping
 
 from rich.console import Console

--- a/tui/tui.py
+++ b/tui/tui.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import multiprocessing as mp
 import os
 from pathlib import Path
 import queue
@@ -10,7 +9,6 @@ import threading
 import textwrap
 import time
 from dataclasses import dataclass, field
-from multiprocessing.synchronize import Event as MpEvent
 from typing import Callable, Mapping
 
 from ..core import AgentFunction, Function, FunctionArg, Node, NodeState, NodeView, TerminalNodeStates, TokenBill
@@ -77,7 +75,7 @@ class _RunRecord:
     fn: Function
     node: Node
     renderer: ConsoleRender
-    cancel_event: MpEvent
+    cancel_event: threading.Event
     latest_view: NodeView | None = None
     terminal_callback_invoked: bool = False
     terminal_browse_applied: bool = False
@@ -708,7 +706,7 @@ class TUI(SessionController):
             self._form_state.error = str(exc)
             return
 
-        cancel_event = mp.Event()
+        cancel_event = threading.Event()
         try:
             node = self.runtime.invoke(
                 None,
@@ -763,7 +761,7 @@ class TUI(SessionController):
 
     def _fatal_after_launch(
         self,
-        cancel_event: MpEvent,
+        cancel_event: threading.Event,
         *,
         fn_name: str,
         node_id: int,
@@ -783,7 +781,7 @@ class TUI(SessionController):
         self,
         message: str,
         *,
-        cancel_event: MpEvent | None = None,
+        cancel_event: threading.Event | None = None,
         exc: BaseException | None = None,
     ) -> None:
         if exc is None:


### PR DESCRIPTION
- (A) Replace inappropriate multiprocessing sync primitives with threading primitives in in-process runtime paths
  - The goal is to stop using `multiprocessing.Lock`, `multiprocessing.Condition`, `multiprocessing.Event`, and related process-backed synchronization objects in places where the framework is actually running threads inside one Python process, not coordinating true child processes.
  - This applies to all the live production code paths: core runtime, node execution, providers, `SessionBag`, text-editor locking, and the TUI launch/cancel path. Excludes tests.
  - The motivation is that process-backed synchronization objects carry heavier OS/resource costs than thread-backed ones, and keeping many of them alive for long-lived TUI trees was a plausible contributor to `OSError: [12]` failures observed using the TUI.
  
- (B) Introduce explicit SessionBag ownership and automatic resource cleanup when a node is terminal
  - `SessionBag` is now treated as an owned container for node-scoped resources rather than just a passive registry.
  - Each node owns its own `SessionBag`.
  - When the node reaches terminal cleanup, the bag is explicitly closed.
  - Closing a `SessionBag`:
    - marks the bag as closed
    - clears the stored entries
    - transitively calls `close()` on any stored owned object that exposes a callable `close()` method
    - tries to `close()` all objects that are closeable even if any one `close()` fails (best-effort).
    - is idempotent, but done under a lock. Follow-ups have no effect.
  - After a `SessionBag` is closed, new `get_or_put()` attempts are rejected.
  - Objects without a `close()` method, or whose `close()` raises, are still released in the sense that the bag drops its references and normal garbage collection can reclaim them.
  - The main purpose is to free long-lived resources promptly when their owning node is done, since they will not be usable again. To prevent resource waste/leak.
  - This is especially relevant for resources like:
    - agent-scoped `BashSession`s
    - top-level text-editor lock objects
    - provider-owned session/client state where node cleanup is the right lifecycle boundary. E.g. anthropic SDK client object instance is released when AnthropicAgentNode goes terminal.

- (C) Make node terminality imply subtree terminality by delaying terminal entry until children are terminal.
  - The framework now enforces a cleaner lifecycle rule:
    a node may determine its terminal outcome before its children are done, but it does not actually enter a terminal state until its direct children are terminal.
  - This means a callable or agent loop can:
    - return
    - raise
    - call `post_success()`
    - call `post_exception()`
    - call `post_cancel()`
    before its children finish, but the runtime will not immediately make the node terminal.
  - Instead, when terminalization is attempted:
    - the runtime waits for the node’s direct children to become terminal
    - during that wait the node remains in `Running`
    - `done` is not set yet
    - terminal cleanup does not run yet
  - Because every child is subject to the same rule before it can itself become terminal, the rule composes inductively:
    - if a node is terminal, then all of its descendants are terminal
    - therefore if a root node is terminal, the entire tree is terminal
  - This is the key safety property that makes `SessionBag` cleanup on node terminalization valid for ancestor/descendant access patterns.
  - It also gives a cleaner reasoning model for the TUI and any external observer:
    root done now means tree done.
  - Even though the framework now guarantees correctness here, authors are still encouraged to explicitly wait on children they launch whenever practical.
  - Explicit child collection is still the cleaner pattern because it keeps outputs, exceptions, and cancellation handling in normal control flow rather than deferring them to framework lifecycle mechanics.

- (D) Make terminal states immutable once reached
  - To preserve the integrity of the subtree-terminal model, the framework now disallows transitions from one terminal state to another.
  - Terminal posting is now first-write-wins.
  - Concretely:
    - if a node has already entered `Success`, a later `post_exception()` or `post_cancel()` is ignored
    - if a node has already entered `Error`, a later `post_success()` or `post_cancel()` is ignored
    - if a node has already entered `Canceled`, a later `post_success()` or `post_exception()` is ignored
  - These later terminal posts do not raise.
  - Instead, they are logged as errors and ignored.
  - This avoids corrupting the final meaning of the node after the runtime has already committed to one terminal outcome.
  - This is necessary both for correctness and for observability:
    external consumers, the TUI, and parent nodes should not see a node’s final outcome mutating after terminalization.
  - This also closes off a class of subtle wrapper/provider bugs where a node could post one terminal result in its own logic and then accidentally be overwritten by later wrapper exception handling.

- (E) Tighten the lifecycle/state-machine API so that (C) and (D) are actually enforceable in practice
  - The old generic "arbitrary status update" mechanism was too broad and created invalid-state escape hatches.
  - It has been narrowed to a dedicated `post_running()` transition.
  - `post_running()` now has a very specific contract:
    - it transitions a node from `Waiting` to `Running`
    - if the node is already `Running`, it is a no-op
    - if the node is already terminal, it is logged and ignored
  - This removes the old ability to set arbitrary node states outside the intended lifecycle.
  - `RunContext.post_running()` is kept as a narrow passthrough because it is useful for framework-facing execution code.
  - The node wrappers now use `post_running()` rather than a generic status-update API.
  - `RunContext.invoke()` is illegal from a node in terminal state.
    - Once a node is actually terminal, further child invocation from that node is rejected (caller sees a RuntimeException, which if they bubble up, framework would log-only since node is already in terminal state).
    - This prevents a terminal node from launching new children after it has become terminal.
  - For `CodeNode`, the callable may explicitly call `ctx.post_success()`, `ctx.post_exception()`, or `ctx.post_cancel()` itself, even though this is undesirable authoring style.
  - If it does so, and then later returns or raises from the Callable (the intended pattern), that later return/raise is ignored (and error-logged) rather than being reposted.
  - This is an important supporting rule because otherwise a callable could explicitly choose one terminal outcome and then accidentally overwrite it by continuing execution.
  - Together, these tightened rules ensure that:
    - `Waiting -> Running` is the only allowed nonterminal state transition
    - terminal posts cannot mutate a node after terminalization
    - terminal nodes cannot launch new children
    - explicit terminal posting inside `CodeFunction` callables is compatible with first-terminal-wins
    - the subtree-terminal cleanup model is not merely documented, but enforced by the actual state machine and runtime behavior